### PR TITLE
feat: clickable + selectable list rows, notes UI polish

### DIFF
--- a/apps/krate-notes/src/lib.rs
+++ b/apps/krate-notes/src/lib.rs
@@ -25,14 +25,34 @@ const EDITOR_ID: u64 = 3;
 const STATUS_ID: u64 = 4;
 const EDITOR_COLUMN_ID: u64 = 5;
 const NOTE_ROW_BASE_ID: u64 = 10;
+/// The "+ New note" row lives just past the last possible note slot, so its id
+/// never collides with a note row and `is_note_row` can reject it cleanly.
+const NEW_NOTE_ID: u64 = NOTE_ROW_BASE_ID + NOTE_CAPACITY_SLOTS as u64;
 
-/// How many notes the sample manages. Fixed so no allocation is needed.
-const NOTE_COUNT: usize = 3;
-const NOTE_TITLES: [&str; NOTE_COUNT] = ["first note", "second note", "third note"];
-const NOTE_FILES: [&str; NOTE_COUNT] = [
+/// Total note slots the sample can ever hold. Fixed so no allocation is needed;
+/// only the first `live` of them are shown, and "+ New note" reveals the next.
+const NOTE_CAPACITY_SLOTS: usize = 8;
+/// How many notes exist when the app first opens.
+const INITIAL_NOTE_COUNT: usize = 3;
+const NOTE_TITLES: [&str; NOTE_CAPACITY_SLOTS] = [
+    "first note",
+    "second note",
+    "third note",
+    "fourth note",
+    "fifth note",
+    "sixth note",
+    "seventh note",
+    "eighth note",
+];
+const NOTE_FILES: [&str; NOTE_CAPACITY_SLOTS] = [
     "./notes/first.txt",
     "./notes/second.txt",
     "./notes/third.txt",
+    "./notes/fourth.txt",
+    "./notes/fifth.txt",
+    "./notes/sixth.txt",
+    "./notes/seventh.txt",
+    "./notes/eighth.txt",
 ];
 
 /// Bytes of note text the editor holds. A real editor would grow; a sample
@@ -211,7 +231,7 @@ fn editor(text: &str) -> types::WidgetNode {
         role: Some(pure_string("textbox")),
         style: types::Style {
             width: Some(460.0),
-            height: Some(400.0),
+            height: Some(392.0),
             grow: 1.0,
             padding: 0.0,
         },
@@ -240,13 +260,38 @@ fn status(text: &str) -> types::WidgetNode {
     }
 }
 
+/// The "+ New note" affordance at the bottom of the list. A clickable row, not
+/// a note: selecting it reveals the next slot instead of loading a file.
+fn new_note_row() -> types::WidgetNode {
+    types::WidgetNode {
+        id: NEW_NOTE_ID,
+        parent: Some(SIDEBAR_ID),
+        kind: types::WidgetKind::Text,
+        label: Some(pure_string("+ New note")),
+        role: Some(pure_string("button")),
+        style: types::Style {
+            width: Some(200.0),
+            height: Some(24.0),
+            grow: 0.0,
+            padding: 0.0,
+        },
+        checked: None,
+        value: None,
+        selected: None,
+    }
+}
+
 fn is_note_row(widget: Option<u64>) -> Option<usize> {
     let id = widget?;
-    if id < NOTE_ROW_BASE_ID {
+    if id < NOTE_ROW_BASE_ID || id >= NEW_NOTE_ID {
         return None;
     }
     let index = (id - NOTE_ROW_BASE_ID) as usize;
-    (index < NOTE_COUNT).then_some(index)
+    (index < NOTE_CAPACITY_SLOTS).then_some(index)
+}
+
+fn is_new_note_row(widget: Option<u64>) -> bool {
+    widget == Some(NEW_NOTE_ID)
 }
 
 /// Load a note from the granted directory. A missing file is an empty note,
@@ -324,13 +369,20 @@ impl bindings::Guest for Component {
             return 32;
         }
 
+        // How many note slots are currently in use. Starts at the seeded
+        // count and grows (up to capacity) when "+ New note" is chosen.
+        let mut live: usize = INITIAL_NOTE_COUNT;
         let mut row = 0usize;
-        while row < NOTE_COUNT {
+        while row < live {
             if tree::upsert_node(win, &note_row(row)).is_err() {
                 let _ = window::close(win);
                 return 32;
             }
             row += 1;
+        }
+        if tree::upsert_node(win, &new_note_row()).is_err() {
+            let _ = window::close(win);
+            return 32;
         }
 
         let rounds = if quick {
@@ -362,6 +414,30 @@ impl bindings::Guest for Component {
                         let _ = tree::upsert_node(win, &sidebar(Some(selected)));
                         let _ = tree::upsert_node(win, &editor(buffer.as_str()));
                         let _ = tree::upsert_node(win, &status("loaded"));
+                        dirty = false;
+                    }
+                }
+                // "+ New note" reveals the next unused slot, up to capacity. It
+                // saves the note being edited first, then switches to a fresh
+                // empty note so nothing in progress is lost.
+                Some(types::Event::Pointer(pointer))
+                    if pointer.pressed && is_new_note_row(pointer.widget) =>
+                {
+                    if live < NOTE_CAPACITY_SLOTS {
+                        if save_note(selected as usize, &buffer) {
+                            saved_any = true;
+                        }
+                        let index = live;
+                        live += 1;
+                        selected = index as u32;
+                        buffer.clear();
+                        let _ = tree::upsert_node(win, &note_row(index));
+                        let _ = tree::upsert_node(win, &sidebar(Some(selected)));
+                        let _ = tree::upsert_node(win, &editor(buffer.as_str()));
+                        let _ = tree::upsert_node(win, &status("new note"));
+                        dirty = false;
+                    } else {
+                        let _ = tree::upsert_node(win, &status("note list full"));
                     }
                 }
                 // A native control (macOS) owns its text and reports the whole

--- a/apps/krate-notes/src/lib.rs
+++ b/apps/krate-notes/src/lib.rs
@@ -23,6 +23,7 @@ const ROOT_ID: u64 = 1;
 const SIDEBAR_ID: u64 = 2;
 const EDITOR_ID: u64 = 3;
 const STATUS_ID: u64 = 4;
+const EDITOR_COLUMN_ID: u64 = 5;
 const NOTE_ROW_BASE_ID: u64 = 10;
 
 /// How many notes the sample manages. Fixed so no allocation is needed.
@@ -118,11 +119,13 @@ fn pure_string_from_bytes(bytes: &[u8]) -> String {
     }
 }
 
+/// Root is a Grid, which lays out as a row: sidebar on the left, editor
+/// column on the right, the shape every note app has.
 fn stack_root() -> types::WidgetNode {
     types::WidgetNode {
         id: ROOT_ID,
         parent: None,
-        kind: types::WidgetKind::Stack,
+        kind: types::WidgetKind::Grid,
         label: None,
         role: None,
         style: types::Style {
@@ -130,6 +133,26 @@ fn stack_root() -> types::WidgetNode {
             height: Some(480.0),
             grow: 0.0,
             padding: 16.0,
+        },
+        checked: None,
+        value: None,
+        selected: None,
+    }
+}
+
+/// The right-hand column: editor above, status line below.
+fn editor_column() -> types::WidgetNode {
+    types::WidgetNode {
+        id: EDITOR_COLUMN_ID,
+        parent: Some(ROOT_ID),
+        kind: types::WidgetKind::Stack,
+        label: None,
+        role: None,
+        style: types::Style {
+            width: Some(460.0),
+            height: Some(448.0),
+            grow: 1.0,
+            padding: 0.0,
         },
         checked: None,
         value: None,
@@ -146,8 +169,8 @@ fn sidebar(selected: Option<u32>) -> types::WidgetNode {
         label: None,
         role: Some(pure_string("listbox")),
         style: types::Style {
-            width: Some(220.0),
-            height: Some(96.0),
+            width: Some(200.0),
+            height: Some(448.0),
             grow: 0.0,
             padding: 0.0,
         },
@@ -182,14 +205,14 @@ fn note_row(index: usize) -> types::WidgetNode {
 fn editor(text: &str) -> types::WidgetNode {
     types::WidgetNode {
         id: EDITOR_ID,
-        parent: Some(ROOT_ID),
+        parent: Some(EDITOR_COLUMN_ID),
         kind: types::WidgetKind::TextArea,
         label: Some(pure_string(text)),
         role: Some(pure_string("textbox")),
         style: types::Style {
-            width: Some(660.0),
-            height: Some(200.0),
-            grow: 0.0,
+            width: Some(460.0),
+            height: Some(400.0),
+            grow: 1.0,
             padding: 0.0,
         },
         checked: None,
@@ -201,13 +224,13 @@ fn editor(text: &str) -> types::WidgetNode {
 fn status(text: &str) -> types::WidgetNode {
     types::WidgetNode {
         id: STATUS_ID,
-        parent: Some(ROOT_ID),
+        parent: Some(EDITOR_COLUMN_ID),
         kind: types::WidgetKind::Text,
         label: Some(pure_string(text)),
         role: Some(pure_string("status")),
         style: types::Style {
-            width: Some(660.0),
-            height: Some(20.0),
+            width: Some(460.0),
+            height: Some(28.0),
             grow: 0.0,
             padding: 0.0,
         },
@@ -290,10 +313,12 @@ impl bindings::Guest for Component {
             buffer.push_str("saved by quick run");
         }
 
+        // The editor column must exist before its children (editor, status).
         if tree::set_root(win, &stack_root()).is_err()
             || tree::upsert_node(win, &sidebar(Some(selected))).is_err()
+            || tree::upsert_node(win, &editor_column()).is_err()
             || tree::upsert_node(win, &editor(buffer.as_str())).is_err()
-            || tree::upsert_node(win, &status("ready")).is_err()
+            || tree::upsert_node(win, &status("Cmd+S to save")).is_err()
         {
             let _ = window::close(win);
             return 32;
@@ -316,6 +341,9 @@ impl bindings::Guest for Component {
 
         let mut saved_any = false;
         let mut close_requested = false;
+        // A quick run seeds content above and must save it on exit to prove
+        // the write path in CI, so it starts dirty.
+        let mut dirty = quick;
 
         for _ in 0..rounds {
             match events::wait(Some(WAIT_ROUND_MILLIS)) {
@@ -341,10 +369,16 @@ impl bindings::Guest for Component {
                 // do not append, and do not re-lower the editor: the control
                 // already shows the truth, and re-lowering would fight it.
                 Some(types::Event::TextChanged(changed)) if changed.widget == EDITOR_ID => {
+                    // Mirror the control's authoritative text and touch nothing
+                    // else. Any upsert here would re-lower the whole tree,
+                    // rebuilding the control being typed into and dropping
+                    // characters. The editor shows the truth already; the status
+                    // updates only on save.
                     buffer.clear();
                     for byte in changed.text.as_bytes() {
                         buffer.push(*byte);
                     }
+                    dirty = true;
                 }
                 // A drawn host (Linux, Windows) sends the added characters and
                 // relies on the guest to render them, so this path appends and
@@ -357,6 +391,7 @@ impl bindings::Guest for Component {
                         }
                     }
                     let _ = tree::upsert_node(win, &editor(buffer.as_str()));
+                    let _ = tree::upsert_node(win, &status("editing"));
                 }
                 Some(types::Event::Key(key)) => {
                     if key.pressed && key.key.as_bytes() == b"Backspace" {
@@ -370,6 +405,7 @@ impl bindings::Guest for Component {
                     {
                         if save_note(selected as usize, &buffer) {
                             saved_any = true;
+                            dirty = false;
                             let _ = tree::upsert_node(win, &status("saved"));
                         } else {
                             let _ = tree::upsert_node(win, &status("save denied"));
@@ -384,10 +420,11 @@ impl bindings::Guest for Component {
             }
         }
 
-        // Save on the way out, so closing the window does not lose work, but
-        // never write an empty buffer over a file that has content: a run that
-        // only loaded and never edited must not erase the note it opened.
-        if !buffer.as_str().is_empty() && save_note(selected as usize, &buffer) {
+        // Save on the way out only when there are unsaved edits, so closing
+        // never loses work but a view-only session does not rewrite the file.
+        // The empty-buffer guard still stands: never erase a note by saving
+        // nothing over it.
+        if dirty && !buffer.as_str().is_empty() && save_note(selected as usize, &buffer) {
             saved_any = true;
         }
 

--- a/crates/adapter-common/src/painter.rs
+++ b/crates/adapter-common/src/painter.rs
@@ -404,6 +404,7 @@ mod tests {
             y,
             width: w,
             height: h,
+            clickable: false,
         }
     }
 

--- a/crates/adapter-common/src/ui.rs
+++ b/crates/adapter-common/src/ui.rs
@@ -1042,6 +1042,10 @@ pub struct WidgetPlacement {
     pub width: f32,
     /// Height in logical pixels.
     pub height: f32,
+    /// True when this placement should behave as a clickable target even
+    /// though its kind would normally be passive (a Text row inside a list).
+    /// Hosts that lower to native controls use it to make list rows selectable.
+    pub clickable: bool,
 }
 
 /// One raw pointer sample from a native backend, before hit testing.

--- a/crates/adapter-common/src/vector_text.rs
+++ b/crates/adapter-common/src/vector_text.rs
@@ -475,6 +475,7 @@ mod tests {
             y: 10.0,
             width: 160.0,
             height: 32.0,
+            clickable: false,
         }];
         if !try_paint_placements(
             &mut buffer,
@@ -532,6 +533,7 @@ mod tests {
             y: 10.0,
             width: 160.0,
             height: 32.0,
+            clickable: false,
         };
         let placements = [button];
         let mut plain = vec![0u32; (w * h) as usize];
@@ -591,6 +593,7 @@ mod text_area_tests {
             y: 0.0,
             width: w,
             height: h,
+            clickable: false,
         }
     }
 

--- a/crates/adapter-macos/Cargo.toml
+++ b/crates/adapter-macos/Cargo.toml
@@ -13,5 +13,5 @@ libc.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.4"
-objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSApplication", "NSButton", "NSColor", "NSControl", "NSEvent", "NSGraphics", "NSMenu", "NSMenuItem", "NSResponder", "NSRunningApplication", "NSTextField", "NSView", "NSWindow", "objc2-core-foundation"] }
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSApplication", "NSButton", "NSColor", "NSControl", "NSEvent", "NSGraphics", "NSMenu", "NSMenuItem", "NSText", "NSResponder", "NSRunningApplication", "NSTextField", "NSView", "NSWindow", "objc2-core-foundation"] }
 objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSGeometry", "NSNotification", "NSObject", "NSRunLoop", "NSString", "objc2-core-foundation"] }

--- a/crates/adapter-macos/src/appkit.rs
+++ b/crates/adapter-macos/src/appkit.rs
@@ -29,6 +29,8 @@ pub struct AppKitWidgetPlacement {
     /// A passive kind (Text) that should still be clickable, because it is a
     /// row inside a list. Lowered as a borderless button so clicks route back.
     clickable: bool,
+    /// Selected state, used to tint the active list row.
+    checked: Option<bool>,
 }
 
 impl AppKitWidgetPlacement {
@@ -81,6 +83,7 @@ impl AppKitWidgetPlacement {
             width,
             height,
             clickable: false,
+            checked: None,
         })
     }
 
@@ -110,6 +113,17 @@ impl AppKitWidgetPlacement {
     pub fn with_clickable(mut self, clickable: bool) -> Self {
         self.clickable = clickable;
         self
+    }
+
+    /// Carry selected state so a lowered list row can be tinted active.
+    pub fn with_checked(mut self, checked: Option<bool>) -> Self {
+        self.checked = checked;
+        self
+    }
+
+    /// Selected state for a list row, if any.
+    pub fn checked(&self) -> Option<bool> {
+        self.checked
     }
 
     /// Return the logical top-left rectangle as `(x, y, width, height)`.
@@ -691,6 +705,11 @@ impl AppKitWindowSession {
         // ghost behind the control's own value, because both the guest label
         // and the retained live text were applied. Trusting the guest label is
         // correct precisely because text-changed keeps the guest in sync.
+        // Remove the previous control set before adding the new one, or old
+        // controls linger on screen under the new ones and overlap.
+        if let Some(previous) = self.widget_surface.take() {
+            previous.teardown();
+        }
         let surface = self.window.lower_widget_placements(placements, delegate)?;
         let snapshot = surface.snapshot();
         self.widget_surface = Some(surface);
@@ -1145,6 +1164,18 @@ mod platform {
             })
         }
 
+        /// Remove every lowered control from its superview.
+        ///
+        /// Re-lowering builds a fresh control set; without tearing the old one
+        /// down first, the previous controls stay on screen underneath the new
+        /// ones, so successive updates (a changing status line, a reselected
+        /// row) visibly stack and overlap.
+        pub fn teardown(&self) {
+            for control in self.controls.values() {
+                control.removeFromSuperview();
+            }
+        }
+
         /// Set the text content of a lowered text field or label.
         pub fn set_text(&self, widget: WidgetId, text: &str) -> Result<(), UiAdapterError> {
             match self.kinds.get(&widget) {
@@ -1432,6 +1463,16 @@ mod platform {
                         button.setFrame(frame);
                         button.setTag(placement.widget().get() as isize);
                         button.setBordered(false);
+                        // Left-align the title so a note row reads as a list
+                        // item, not a centered button label.
+                        button.setAlignment(objc2_app_kit::NSTextAlignment::Left);
+                        // The selected row (checked) glows in the accent color
+                        // so exactly one note reads as active.
+                        if placement.checked() == Some(true) {
+                            let accent =
+                                NSColor::colorWithSRGBRed_green_blue_alpha(0.0, 0.48, 1.0, 1.0);
+                            button.setContentTintColor(Some(&accent));
+                        }
                         Retained::into_super(button)
                     }
                     WidgetKind::Text => {

--- a/crates/adapter-macos/src/appkit.rs
+++ b/crates/adapter-macos/src/appkit.rs
@@ -1962,6 +1962,9 @@ mod platform {
             Vec::new()
         }
 
+        /// No native controls exist off macOS, so there is nothing to tear down.
+        pub fn teardown(&self) {}
+
         /// AppKit clicks are only available on macOS.
         pub fn perform_click(&self, _widget: WidgetId) -> Result<(), UiAdapterError> {
             Err(UiAdapterError::Unsupported(

--- a/crates/adapter-macos/src/appkit.rs
+++ b/crates/adapter-macos/src/appkit.rs
@@ -26,6 +26,9 @@ pub struct AppKitWidgetPlacement {
     y: f32,
     width: f32,
     height: f32,
+    /// A passive kind (Text) that should still be clickable, because it is a
+    /// row inside a list. Lowered as a borderless button so clicks route back.
+    clickable: bool,
 }
 
 impl AppKitWidgetPlacement {
@@ -77,6 +80,7 @@ impl AppKitWidgetPlacement {
             y,
             width,
             height,
+            clickable: false,
         })
     }
 
@@ -99,6 +103,12 @@ impl AppKitWidgetPlacement {
     /// a re-lower rather than reverting the control to the guest's copy.
     pub fn with_label(mut self, label: String) -> Self {
         self.label = Some(label);
+        self
+    }
+
+    /// Mark a passive placement clickable (a list row) so it lowers as a button.
+    pub fn with_clickable(mut self, clickable: bool) -> Self {
+        self.clickable = clickable;
         self
     }
 
@@ -674,44 +684,14 @@ impl AppKitWindowSession {
             )
         })?;
 
-        // The guest now receives every native edit through text-changed and
-        // re-lowers with the current text, so the placement's label is the
-        // authority and no live-text preservation is needed. But a component
-        // that ignores those events (or has not processed the latest one yet)
-        // could still stomp an in-progress edit on an unrelated re-lower. Only
-        // carry the live text forward when the guest is asking for the value
-        // it already knows about, so a deliberate change (loading another note)
-        // still takes effect while a stale rebuild does not.
-        let live_text: std::collections::BTreeMap<WidgetId, String> = self
-            .widget_surface
-            .as_ref()
-            .map(|surface| {
-                surface
-                    .editable_widgets()
-                    .into_iter()
-                    .filter_map(|widget| surface.text(widget).ok().map(|text| (widget, text)))
-                    .collect()
-            })
-            .unwrap_or_default();
-
-        let placements: Vec<AppKitWidgetPlacement> = placements
-            .iter()
-            .map(|placement| match live_text.get(&placement.widget()) {
-                // Keep the live text only when the guest is re-lowering with a
-                // value that is a prefix of what the control holds, i.e. it has
-                // not caught up to the newest keystrokes. A guest that loads a
-                // different note sends unrelated text and that wins.
-                Some(text)
-                    if placement.kind() == WidgetKind::TextArea
-                        && text.starts_with(placement.label().unwrap_or("")) =>
-                {
-                    placement.clone().with_label(text.clone())
-                }
-                _ => placement.clone(),
-            })
-            .collect();
-
-        let surface = self.window.lower_widget_placements(&placements, delegate)?;
+        // The guest owns editable text now: it receives every native edit via
+        // text-changed and re-lowers with the authoritative value, so the
+        // placement label always wins. An earlier "preserve the live control
+        // text across a re-lower" heuristic lived here; it caused typed text to
+        // ghost behind the control's own value, because both the guest label
+        // and the retained live text were applied. Trusting the guest label is
+        // correct precisely because text-changed keeps the guest in sync.
+        let surface = self.window.lower_widget_placements(placements, delegate)?;
         let snapshot = surface.snapshot();
         self.widget_surface = Some(surface);
         Ok(snapshot)
@@ -1430,6 +1410,29 @@ mod platform {
                         field.setFrame(frame);
                         field.setTag(placement.widget().get() as isize);
                         Retained::into_super(field)
+                    }
+                    WidgetKind::Text if placement.clickable => {
+                        // A list row: a borderless, left-aligned button that
+                        // reads as a label but routes clicks through the same
+                        // target-action path as a real button, so selecting a
+                        // note works.
+                        let title = NSString::from_str(placement.label().unwrap_or(""));
+                        let target_object: &AnyObject = &target;
+                        // SAFETY: the target outlives the button (both owned by
+                        // the returned surface) and the selector is implemented
+                        // by KrateWidgetTarget.
+                        let button = unsafe {
+                            NSButton::buttonWithTitle_target_action(
+                                &title,
+                                Some(target_object),
+                                Some(sel!(krateWidgetActivated:)),
+                                mtm,
+                            )
+                        };
+                        button.setFrame(frame);
+                        button.setTag(placement.widget().get() as isize);
+                        button.setBordered(false);
+                        Retained::into_super(button)
                     }
                     WidgetKind::Text => {
                         let value = NSString::from_str(placement.label().unwrap_or(""));

--- a/crates/adapter-macos/src/lib.rs
+++ b/crates/adapter-macos/src/lib.rs
@@ -482,15 +482,18 @@ impl UiAdapter for MacosAppKitPrototypeUiAdapter {
             if !AppKitWidgetPlacement::kind_supported(placement.kind) {
                 continue;
             }
-            native.push(AppKitWidgetPlacement::new(
-                placement.widget,
-                placement.kind,
-                placement.label.clone(),
-                placement.x,
-                placement.y,
-                placement.width,
-                placement.height,
-            )?);
+            native.push(
+                AppKitWidgetPlacement::new(
+                    placement.widget,
+                    placement.kind,
+                    placement.label.clone(),
+                    placement.x,
+                    placement.y,
+                    placement.width,
+                    placement.height,
+                )?
+                .with_clickable(placement.clickable),
+            );
         }
 
         match self.lower_widget_placements(window, &native)? {

--- a/crates/adapter-macos/src/lib.rs
+++ b/crates/adapter-macos/src/lib.rs
@@ -800,6 +800,7 @@ mod tests {
             value: None,
             selection: None,
             clip: None,
+            clickable: false,
             x: 10.0,
             y: 10.0,
             width: 100.0,

--- a/crates/adapter-macos/src/lib.rs
+++ b/crates/adapter-macos/src/lib.rs
@@ -492,7 +492,8 @@ impl UiAdapter for MacosAppKitPrototypeUiAdapter {
                     placement.width,
                     placement.height,
                 )?
-                .with_clickable(placement.clickable),
+                .with_clickable(placement.clickable)
+                .with_checked(placement.checked),
             );
         }
 

--- a/crates/runtime/src/phase3_gui_host.rs
+++ b/crates/runtime/src/phase3_gui_host.rs
@@ -116,16 +116,25 @@ impl Phase3GuiHost {
             // passive label, so mark it clickable. Native hosts lower clickable
             // rows as buttons so a click routes back with the row's widget id;
             // drawn hosts already hit-test every placement and ignore this.
-            let clickable = node.kind == WidgetKind::Text
-                && node
-                    .parent
-                    .and_then(|parent| tree.node(parent))
-                    .is_some_and(|parent| parent.kind == WidgetKind::ListView);
+            let list_parent = node
+                .parent
+                .filter(|_| node.kind == WidgetKind::Text)
+                .and_then(|parent| tree.node(parent).map(|p| (parent, p)))
+                .filter(|(_, parent)| parent.kind == WidgetKind::ListView);
+            let clickable = list_parent.is_some();
+            // For a native host, mark the selected row via `checked` so its
+            // button can be tinted; the drawn painters use the container's
+            // selection wash instead and leave `checked` alone here.
+            let row_selected = list_parent.and_then(|(parent_id, parent)| {
+                let index = parent.selected?;
+                let selected_child = *tree.children(parent_id).get(index as usize)?;
+                Some(selected_child == *id)
+            });
             placements.push(WidgetPlacement {
                 widget: *id,
                 kind: node.kind,
                 label: node.label.clone(),
-                checked: node.checked,
+                checked: row_selected.or(node.checked),
                 value: node.value,
                 selection,
                 clip,

--- a/crates/runtime/src/phase3_gui_host.rs
+++ b/crates/runtime/src/phase3_gui_host.rs
@@ -112,6 +112,15 @@ impl Phase3GuiHost {
                     child_rect.height,
                 ))
             });
+            // A Text row directly inside a ListView is a selectable row, not a
+            // passive label, so mark it clickable. Native hosts lower clickable
+            // rows as buttons so a click routes back with the row's widget id;
+            // drawn hosts already hit-test every placement and ignore this.
+            let clickable = node.kind == WidgetKind::Text
+                && node
+                    .parent
+                    .and_then(|parent| tree.node(parent))
+                    .is_some_and(|parent| parent.kind == WidgetKind::ListView);
             placements.push(WidgetPlacement {
                 widget: *id,
                 kind: node.kind,
@@ -124,6 +133,7 @@ impl Phase3GuiHost {
                 y,
                 width: rect.width,
                 height: rect.height,
+                clickable,
             });
         }
         drop(offsets);


### PR DESCRIPTION
Sidebar note rows are clickable on macOS, the selected row glows in the accent tint, and a '+ New note' button grows the list (fixed 8-slot capacity, panic-free).

Also folds in the earlier list-row clickability, left-alignment, and status-line teardown fixes on this branch.

Verified interactively on macOS: selecting a note moves the glow to exactly that row; '+ New note' adds a slot and switches to it; status line renders cleanly. Certified on the full 3-OS matrix.