### PR TITLE
feat: native consent window — a .krate asks before it runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,8 +286,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: hello-fixture
     # A stuck runner (a hung evidence step, a stalled GUI proof) must fail the
-    # lane, not sit at GitHub's 6-hour default. These lanes finish in ~25 min.
-    timeout-minutes: 45
+    # lane, not sit at GitHub's 6-hour default. Ubuntu/macOS finish in ~25 min,
+    # but the Windows lane legitimately takes ~53 (slower runner + cache save),
+    # so 75 leaves margin while still catching a real hang.
+    timeout-minutes: 75
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,6 +446,43 @@ jobs:
             exit 1
           fi
           echo "withholding fs.write stopped krate-notes before it ran (exit 5)"
+          # Consent path (P3-OPEN-01). The native window is macOS-only; on Linux
+          # --consent falls back to the terminal prompt, so this proves the
+          # consent semantics: allowing grants exactly what was requested and the
+          # app runs, and refusing yields the same structured denial (exit 5) as
+          # a withheld --grant. The two paths must agree on the grant set.
+          consent_dir="$RUNNER_TEMP/notes-consent"
+          rm -rf "$consent_dir" && mkdir -p "$consent_dir/notes"
+          cp "$notes_dir/notes.krate" "$consent_dir/notes.krate"
+          # Allow all: pipe "A" to the fallback prompt. The app should run and
+          # save, proving consent granted the same caps a direct --grant would.
+          ( cd "$consent_dir" && printf 'A\n' | "$GITHUB_WORKSPACE/target/debug/krate" \
+              run notes.krate --consent -- quick ) || {
+            echo "expected --consent (allow all) to run krate-notes" >&2
+            exit 1
+          }
+          if [ ! -s "$consent_dir/notes/first.txt" ]; then
+            echo "consent (allow all) should have saved a note" >&2
+            exit 1
+          fi
+          echo "consent allow-all granted the requested caps and the app saved"
+          # Refuse: pipe "N". The app must not run and must exit 5, the same
+          # denial a withheld grant produces.
+          rm -rf "$consent_dir/notes" && mkdir -p "$consent_dir/notes"
+          set +e
+          ( cd "$consent_dir" && printf 'N\n' | "$GITHUB_WORKSPACE/target/debug/krate" \
+              run notes.krate --consent -- quick )
+          consent_denied=$?
+          set -e
+          if [ "$consent_denied" != "5" ]; then
+            echo "expected exit 5 when consent is refused, got $consent_denied" >&2
+            exit 1
+          fi
+          if [ -s "$consent_dir/notes/first.txt" ]; then
+            echo "refused consent must not have let the app write" >&2
+            exit 1
+          fi
+          echo "refusing consent stopped krate-notes before it ran (exit 5)"
       - name: Upload Linux drawn-window screenshot
         if: always() && matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,6 +285,9 @@ jobs:
     if: ${{ (github.event_name == 'workflow_dispatch' && inputs.full) || (github.event_name == 'push' && contains(github.event.head_commit.message, '[full-ci]')) }}
     runs-on: ${{ matrix.os }}
     needs: hello-fixture
+    # A stuck runner (a hung evidence step, a stalled GUI proof) must fail the
+    # lane, not sit at GitHub's 6-hour default. These lanes finish in ~25 min.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "docs/book/**"
+      - "docs/landing/**"
       - ".github/workflows/pages.yml"
   workflow_dispatch:
 
@@ -35,12 +36,21 @@ jobs:
           echo "$HOME/bin" >> $GITHUB_PATH
       - name: Build docs
         run: mdbook build docs/book
+      - name: Assemble site — landing page at root, docs under /docs/
+        run: |
+          # The published site root is the landing page; the mdBook lives at
+          # /docs/ (its site-url is set to /krate/docs/ to match). Assemble both
+          # into one directory to upload.
+          rm -rf _site
+          mkdir -p _site
+          cp docs/landing/index.html _site/index.html
+          cp -R docs/book/book _site/docs
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:
-          path: docs/book/book
+          path: _site
 
   deploy:
     name: Deploy to GitHub Pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,11 +79,25 @@ jobs:
           KRATE_VERSION: ${{ github.ref_name }}
         run: scripts/package.sh "${{ matrix.target }}" "${{ matrix.ext }}"
 
+      - name: Assemble Krate.app (macOS double-click entry point)
+        if: contains(matrix.target, 'apple-darwin')
+        shell: bash
+        env:
+          KRATE_VERSION: ${{ github.ref_name }}
+        run: |
+          # Pillow renders the app icon; ship without an icon rather than fail.
+          python3 -m pip install --quiet pillow || true
+          KRATE_BINARY="target/${{ matrix.target }}/release/krate"             scripts/make-macos-app.sh dist
+          version="${KRATE_VERSION#v}"
+          (cd dist && zip -qry "krate-app-${version}-${{ matrix.target }}.zip" Krate.app)
+
       - name: Upload packaged artifact
         uses: actions/upload-artifact@v7
         with:
           name: krate-${{ matrix.target }}
-          path: dist/krate-*.${{ matrix.ext }}
+          path: |
+            dist/krate-*.${{ matrix.ext }}
+            dist/krate-app-*.zip
           if-no-files-found: error
 
   publish:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1611,6 +1611,7 @@ version = "0.1.0-dev"
 dependencies = [
  "anyhow",
  "clap",
+ "krate-adapter-macos",
  "krate-bundle",
  "krate-manifest",
  "krate-policy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1665,6 +1665,7 @@ dependencies = [
  "krate-manifest",
  "krate-policy",
  "libc",
+ "tempfile",
  "thiserror 2.0.18",
  "tracing",
  "wasmtime",

--- a/Plan/Plan-Amendments-2026-07.md
+++ b/Plan/Plan-Amendments-2026-07.md
@@ -562,14 +562,28 @@ Definition of done:
    slice) shows a native dialog listing app id and every requested capability
    with its `rationale` from the in-bundle manifest, before instantiation.
 2. Allow grants exactly the listed capabilities for that session and nothing
-   else; Deny refuses and the component never runs.
+   else; Deny refuses and the component never runs. Consent is per-capability:
+   the window lists each requested (non-default-granted) capability with the
+   author's rationale and a per-capability allow/deny, mirroring the existing
+   terminal `prompt_for_session_grants` semantics exactly — the same
+   `SessionPolicy::from_grants` fold, so the native and terminal paths produce
+   identical grant sets.
 3. A denied or partially-denied set produces the same structured denial a
    withheld `--grant` produces today — no new denial semantics.
-4. The dialog is implemented once in a shared place and lowered per-OS; the
-   non-macOS path has a working equivalent or an explicit, tested stub (the
-   off-macOS-stub gap has bitten this codebase before — the stub must compile
-   and be exercised on the Linux and Windows lanes, not only macOS).
-5. Full CI matrix green on all three OS lanes.
+4. **Platform scope for this slice (founder decision, 2026-07-23): the rich
+   native consent window is macOS-only for now.** Linux and Windows keep the
+   existing terminal `--prompt` path unchanged; a portable consent window on the
+   other OSes is deferred to after the demo (a later P3-OPEN slice, not this
+   one). The macOS window lives in `adapter-macos`; the non-macOS build must
+   still compile and be exercised — the code path selecting native-vs-terminal
+   consent needs a stub or fallback that the Linux and Windows lanes actually
+   run (the off-macOS-stub gap has bitten this codebase twice; do not let a
+   macOS-only method be called unconditionally).
+5. Full CI matrix green on all three OS lanes. Because the native window is
+   macOS-only, the Linux CI proof exercises the consent *semantics* (grant set
+   equals what was allowed; a withheld required capability yields the same
+   structured denial and exit code) rather than the macOS window itself — the
+   proof must assert something real, not that a stub returned.
 
 Verification: extend the existing Xvfb proof so the Linux robot opens a bundle
 in consent mode, sees the dialog, allows it, and screenshots the running app;

--- a/apps/krate-notes/src/lib.rs
+++ b/apps/krate-notes/src/lib.rs
@@ -20,10 +20,15 @@ use bindings::krate::io::{args, stdio};
 use bindings::krate::ui::{events, tree, types, window};
 
 const ROOT_ID: u64 = 1;
-const SIDEBAR_ID: u64 = 2;
+/// The left column wraps a header label and the note list. Child order is
+/// BTreeMap id order, so the left column's id must sort before the editor
+/// column's for the sidebar to sit on the left.
+const LEFT_COLUMN_ID: u64 = 2;
 const EDITOR_ID: u64 = 3;
 const STATUS_ID: u64 = 4;
 const EDITOR_COLUMN_ID: u64 = 5;
+const SIDEBAR_HEADER_ID: u64 = 6;
+const SIDEBAR_ID: u64 = 7;
 const NOTE_ROW_BASE_ID: u64 = 10;
 /// The "+ New note" row lives just past the last possible note slot, so its id
 /// never collides with a note row and `is_note_row` can reject it cleanly.
@@ -180,17 +185,58 @@ fn editor_column() -> types::WidgetNode {
     }
 }
 
+/// The left column: a header label above the note list.
+fn left_column() -> types::WidgetNode {
+    types::WidgetNode {
+        id: LEFT_COLUMN_ID,
+        parent: Some(ROOT_ID),
+        kind: types::WidgetKind::Stack,
+        label: None,
+        role: None,
+        style: types::Style {
+            width: Some(200.0),
+            height: Some(448.0),
+            grow: 0.0,
+            padding: 0.0,
+        },
+        checked: None,
+        value: None,
+        selected: None,
+    }
+}
+
+/// The list's header. A plain label: its parent is the Stack, not the
+/// ListView, so the host does not lower it as a clickable row.
+fn sidebar_header() -> types::WidgetNode {
+    types::WidgetNode {
+        id: SIDEBAR_HEADER_ID,
+        parent: Some(LEFT_COLUMN_ID),
+        kind: types::WidgetKind::Text,
+        label: Some(pure_string("Notes")),
+        role: Some(pure_string("heading")),
+        style: types::Style {
+            width: Some(200.0),
+            height: Some(30.0),
+            grow: 0.0,
+            padding: 0.0,
+        },
+        checked: None,
+        value: None,
+        selected: None,
+    }
+}
+
 /// The note list. Selection lives here, so the host paints the highlight.
 fn sidebar(selected: Option<u32>) -> types::WidgetNode {
     types::WidgetNode {
         id: SIDEBAR_ID,
-        parent: Some(ROOT_ID),
+        parent: Some(LEFT_COLUMN_ID),
         kind: types::WidgetKind::ListView,
         label: None,
         role: Some(pure_string("listbox")),
         style: types::Style {
             width: Some(200.0),
-            height: Some(448.0),
+            height: Some(418.0),
             grow: 0.0,
             padding: 0.0,
         },
@@ -211,7 +257,7 @@ fn note_row(index: usize) -> types::WidgetNode {
         role: Some(pure_string("option")),
         style: types::Style {
             width: Some(200.0),
-            height: Some(24.0),
+            height: Some(28.0),
             grow: 0.0,
             padding: 0.0,
         },
@@ -271,7 +317,7 @@ fn new_note_row() -> types::WidgetNode {
         role: Some(pure_string("button")),
         style: types::Style {
             width: Some(200.0),
-            height: Some(24.0),
+            height: Some(28.0),
             grow: 0.0,
             padding: 0.0,
         },
@@ -360,6 +406,8 @@ impl bindings::Guest for Component {
 
         // The editor column must exist before its children (editor, status).
         if tree::set_root(win, &stack_root()).is_err()
+            || tree::upsert_node(win, &left_column()).is_err()
+            || tree::upsert_node(win, &sidebar_header()).is_err()
             || tree::upsert_node(win, &sidebar(Some(selected))).is_err()
             || tree::upsert_node(win, &editor_column()).is_err()
             || tree::upsert_node(win, &editor(buffer.as_str())).is_err()
@@ -370,8 +418,19 @@ impl bindings::Guest for Component {
         }
 
         // How many note slots are currently in use. Starts at the seeded
-        // count and grows (up to capacity) when "+ New note" is chosen.
+        // count, grows when "+ New note" is chosen, and re-discovers notes
+        // created in earlier sessions by probing which files exist — a note
+        // added yesterday must still be in the list today.
         let mut live: usize = INITIAL_NOTE_COUNT;
+        while live < NOTE_CAPACITY_SLOTS {
+            let Some(path) = NOTE_FILES.get(live) else {
+                break;
+            };
+            if files::open(path, OpenMode::Read).is_err() {
+                break;
+            }
+            live += 1;
+        }
         let mut row = 0usize;
         while row < live {
             if tree::upsert_node(win, &note_row(row)).is_err() {

--- a/crates/adapter-common/src/painter.rs
+++ b/crates/adapter-common/src/painter.rs
@@ -405,6 +405,7 @@ mod tests {
             width: w,
             height: h,
             clickable: false,
+            role: None,
         }
     }
 

--- a/crates/adapter-common/src/ui.rs
+++ b/crates/adapter-common/src/ui.rs
@@ -1046,6 +1046,10 @@ pub struct WidgetPlacement {
     /// though its kind would normally be passive (a Text row inside a list).
     /// Hosts that lower to native controls use it to make list rows selectable.
     pub clickable: bool,
+    /// Semantic role carried from the widget node ("heading", "status",
+    /// "textbox", "option", "button"). Styling stays out of the guest
+    /// contract; hosts may use the role to pick native typography.
+    pub role: Option<String>,
 }
 
 /// One raw pointer sample from a native backend, before hit testing.

--- a/crates/adapter-common/src/vector_text.rs
+++ b/crates/adapter-common/src/vector_text.rs
@@ -476,6 +476,7 @@ mod tests {
             width: 160.0,
             height: 32.0,
             clickable: false,
+            role: None,
         }];
         if !try_paint_placements(
             &mut buffer,
@@ -534,6 +535,7 @@ mod tests {
             width: 160.0,
             height: 32.0,
             clickable: false,
+            role: None,
         };
         let placements = [button];
         let mut plain = vec![0u32; (w * h) as usize];
@@ -594,6 +596,7 @@ mod text_area_tests {
             width: w,
             height: h,
             clickable: false,
+            role: None,
         }
     }
 

--- a/crates/adapter-macos/Cargo.toml
+++ b/crates/adapter-macos/Cargo.toml
@@ -13,5 +13,5 @@ libc.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.4"
-objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSApplication", "NSButton", "NSCell", "NSColor", "NSControl", "NSEvent", "NSFont", "NSGraphics", "NSMenu", "NSMenuItem", "NSText", "NSResponder", "NSRunningApplication", "NSTextField", "NSView", "NSWindow", "objc2-core-foundation"] }
-objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSArray", "NSGeometry", "NSNotification", "NSObject", "NSRunLoop", "NSString", "objc2-core-foundation"] }
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSApplication", "NSButton", "NSCell", "NSColor", "NSControl", "NSEvent", "NSFont", "NSGraphics", "NSMenu", "NSMenuItem", "NSOpenPanel", "NSPanel", "NSSavePanel", "NSText", "NSResponder", "NSRunningApplication", "NSTextField", "NSView", "NSWindow", "objc2-core-foundation"] }
+objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSArray", "NSGeometry", "NSURL", "NSNotification", "NSObject", "NSRunLoop", "NSString", "objc2-core-foundation"] }

--- a/crates/adapter-macos/Cargo.toml
+++ b/crates/adapter-macos/Cargo.toml
@@ -13,5 +13,5 @@ libc.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.4"
-objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSApplication", "NSButton", "NSColor", "NSControl", "NSEvent", "NSGraphics", "NSMenu", "NSMenuItem", "NSText", "NSResponder", "NSRunningApplication", "NSTextField", "NSView", "NSWindow", "objc2-core-foundation"] }
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSApplication", "NSButton", "NSCell", "NSColor", "NSControl", "NSEvent", "NSFont", "NSGraphics", "NSMenu", "NSMenuItem", "NSText", "NSResponder", "NSRunningApplication", "NSTextField", "NSView", "NSWindow", "objc2-core-foundation"] }
 objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSGeometry", "NSNotification", "NSObject", "NSRunLoop", "NSString", "objc2-core-foundation"] }

--- a/crates/adapter-macos/Cargo.toml
+++ b/crates/adapter-macos/Cargo.toml
@@ -14,4 +14,4 @@ libc.workspace = true
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.4"
 objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSApplication", "NSButton", "NSCell", "NSColor", "NSControl", "NSEvent", "NSFont", "NSGraphics", "NSMenu", "NSMenuItem", "NSText", "NSResponder", "NSRunningApplication", "NSTextField", "NSView", "NSWindow", "objc2-core-foundation"] }
-objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSGeometry", "NSNotification", "NSObject", "NSRunLoop", "NSString", "objc2-core-foundation"] }
+objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSArray", "NSGeometry", "NSNotification", "NSObject", "NSRunLoop", "NSString", "objc2-core-foundation"] }

--- a/crates/adapter-macos/src/appkit.rs
+++ b/crates/adapter-macos/src/appkit.rs
@@ -31,6 +31,8 @@ pub struct AppKitWidgetPlacement {
     clickable: bool,
     /// Selected state, used to tint the active list row.
     checked: Option<bool>,
+    /// Semantic role from the widget node; used to pick native typography.
+    role: Option<String>,
 }
 
 impl AppKitWidgetPlacement {
@@ -84,6 +86,7 @@ impl AppKitWidgetPlacement {
             height,
             clickable: false,
             checked: None,
+            role: None,
         })
     }
 
@@ -124,6 +127,17 @@ impl AppKitWidgetPlacement {
     /// Selected state for a list row, if any.
     pub fn checked(&self) -> Option<bool> {
         self.checked
+    }
+
+    /// Carry the node's semantic role so lowering can style natively.
+    pub fn with_role(mut self, role: Option<String>) -> Self {
+        self.role = role;
+        self
+    }
+
+    /// Semantic role, if the node declared one.
+    pub fn role(&self) -> Option<&str> {
+        self.role.as_deref()
     }
 
     /// Return the logical top-left rectangle as `(x, y, width, height)`.
@@ -1065,7 +1079,7 @@ mod platform {
     use objc2::{define_class, msg_send, sel, DefinedClass, MainThreadMarker, MainThreadOnly};
     use objc2_app_kit::{
         NSApplication, NSApplicationActivationPolicy, NSBackingStoreType, NSButton, NSColor,
-        NSControl, NSEventMask, NSMenu, NSMenuItem, NSTextField, NSView, NSWindow,
+        NSControl, NSEventMask, NSFont, NSMenu, NSMenuItem, NSTextField, NSView, NSWindow,
         NSWindowDelegate, NSWindowStyleMask,
     };
     use objc2_foundation::{
@@ -1466,12 +1480,17 @@ mod platform {
                         // Left-align the title so a note row reads as a list
                         // item, not a centered button label.
                         button.setAlignment(objc2_app_kit::NSTextAlignment::Left);
+                        button.setFont(Some(&NSFont::systemFontOfSize(13.0)));
                         // The selected row (checked) glows in the accent color
-                        // so exactly one note reads as active.
+                        // so exactly one note reads as active. An action row
+                        // (role "button", e.g. "+ New note") reads quieter than
+                        // the content rows.
                         if placement.checked() == Some(true) {
                             let accent =
                                 NSColor::colorWithSRGBRed_green_blue_alpha(0.0, 0.48, 1.0, 1.0);
                             button.setContentTintColor(Some(&accent));
+                        } else if placement.role() == Some("button") {
+                            button.setContentTintColor(Some(&NSColor::secondaryLabelColor()));
                         }
                         Retained::into_super(button)
                     }
@@ -1480,6 +1499,21 @@ mod platform {
                         let label = NSTextField::labelWithString(&value, mtm);
                         label.setFrame(frame);
                         label.setTag(placement.widget().get() as isize);
+                        // Roles pick native typography: a heading is a bold
+                        // sidebar section label, a status line is small and
+                        // quiet. Styling lives here, in the host, never in
+                        // the guest contract.
+                        match placement.role() {
+                            Some("heading") => {
+                                label.setFont(Some(&NSFont::boldSystemFontOfSize(13.0)));
+                                label.setTextColor(Some(&NSColor::secondaryLabelColor()));
+                            }
+                            Some("status") => {
+                                label.setFont(Some(&NSFont::systemFontOfSize(11.0)));
+                                label.setTextColor(Some(&NSColor::tertiaryLabelColor()));
+                            }
+                            _ => {}
+                        }
                         Retained::into_super(label)
                     }
                     WidgetKind::TextArea => {
@@ -1494,6 +1528,16 @@ mod platform {
                         field.setTag(placement.widget().get() as isize);
                         field.setEditable(true);
                         field.setSelectable(true);
+                        // Borderless but with the system text background, so
+                        // it reads as a writing surface — a fully transparent
+                        // empty field is invisible on a dark window, which
+                        // left no cue where to type. The placeholder makes the
+                        // surface discoverable before the first keystroke.
+                        field.setBezeled(false);
+                        field.setDrawsBackground(true);
+                        field.setBackgroundColor(Some(&NSColor::textBackgroundColor()));
+                        field.setFont(Some(&NSFont::systemFontOfSize(15.0)));
+                        field.setPlaceholderString(Some(&NSString::from_str("Write your note…")));
                         Retained::into_super(field)
                     }
                     WidgetKind::ListView => {
@@ -1519,6 +1563,19 @@ mod platform {
                 controls.insert(placement.widget(), control);
                 kinds.insert(placement.widget(), placement.kind());
                 lowered.push(placement.widget());
+            }
+
+            // Focus the editor so typing works the moment the window opens —
+            // without this, an untouched window sends keystrokes nowhere and
+            // the app looks like it ignores input.
+            let first_editor = lowered
+                .iter()
+                .find(|id| kinds.get(id) == Some(&WidgetKind::TextArea));
+            if let Some(id) = first_editor {
+                if let Some(control) = controls.get(id) {
+                    let responder: &objc2_app_kit::NSResponder = control;
+                    self.window.makeFirstResponder(Some(responder));
+                }
             }
 
             Ok(AppKitWidgetSurface {

--- a/crates/adapter-macos/src/consent.rs
+++ b/crates/adapter-macos/src/consent.rs
@@ -1,0 +1,313 @@
+//! The macOS native consent window (P3-OPEN-01).
+//!
+//! When a `.krate` is opened without pre-supplied grants — the double-click
+//! path, where there is no terminal to answer — this presents a modal window
+//! naming the app and listing each requested capability with the author's
+//! rationale and a per-capability checkbox. The person allows a subset and
+//! presses Open, or presses Cancel and nothing runs.
+//!
+//! This window is macOS-only for now (founder decision, 2026-07-23). Linux and
+//! Windows keep the terminal consent prompt; the CLI selects between them and
+//! falls back to the terminal when [`present_consent_window`] reports the
+//! platform is unsupported. The non-macOS build of this module is a stub that
+//! compiles and returns that fallback signal, so the off-macOS path is exercised
+//! on those CI lanes rather than left to break a later build.
+
+use krate_adapter_common::ui::UiAdapterError;
+
+/// One capability shown as a row in the consent window.
+#[derive(Debug, Clone)]
+pub struct ConsentItem {
+    /// The capability string as the person should read it (e.g. the grant).
+    pub display: String,
+    /// The author's own reason for requesting it, from the manifest.
+    pub rationale: String,
+    /// Whether the app cannot run without it. Required rows start checked.
+    pub required: bool,
+}
+
+/// What the person decided in the consent window.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConsentChoice {
+    /// They pressed Open; the indices are the rows they left checked, into the
+    /// `items` slice passed to [`present_consent_window`].
+    Open(Vec<usize>),
+    /// They pressed Cancel; nothing is granted and the run is refused.
+    Cancel,
+}
+
+/// Present the consent window and block until the person decides.
+///
+/// On macOS this runs a modal AppKit window on the main thread. On every other
+/// platform it returns `Unsupported` via an error the CLI treats as "fall back
+/// to the terminal prompt", so `--consent` still works there.
+#[cfg(target_os = "macos")]
+pub fn present_consent_window(
+    app_name: &str,
+    app_id: &str,
+    items: &[ConsentItem],
+) -> Result<ConsentChoice, UiAdapterError> {
+    platform::present(app_name, app_id, items)
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn present_consent_window(
+    _app_name: &str,
+    _app_id: &str,
+    _items: &[ConsentItem],
+) -> Result<ConsentChoice, UiAdapterError> {
+    Err(UiAdapterError::Unsupported(
+        "the native consent window is only available on macOS".to_string(),
+    ))
+}
+
+#[cfg(target_os = "macos")]
+mod platform {
+    use super::{ConsentChoice, ConsentItem};
+    use krate_adapter_common::ui::UiAdapterError;
+    use objc2::rc::Retained;
+    use objc2::runtime::AnyObject;
+    use objc2::{define_class, msg_send, sel, DefinedClass, MainThreadMarker, MainThreadOnly};
+    use objc2_app_kit::{
+        NSApplication, NSBackingStoreType, NSButton, NSColor, NSControlStateValueOff,
+        NSControlStateValueOn, NSFont, NSTextField, NSView, NSWindow, NSWindowStyleMask,
+    };
+    use objc2_foundation::{NSPoint, NSRect, NSSize, NSString};
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    /// Modal return codes. Distinct so the caller can tell Open from Cancel;
+    /// AppKit reserves nothing in this range for its own responses here.
+    const RESPONSE_OPEN: isize = 1000;
+    const RESPONSE_CANCEL: isize = 1001;
+
+    // Window geometry. Fixed width, height grows with the row count up to a cap.
+    const WINDOW_WIDTH: f64 = 460.0;
+    const ROW_HEIGHT: f64 = 52.0;
+    const HEADER_HEIGHT: f64 = 72.0;
+    const FOOTER_HEIGHT: f64 = 64.0;
+    const MAX_LIST_HEIGHT: f64 = 360.0;
+
+    struct ButtonTargetIvars {
+        // Which button was pressed, written by the action and read after the
+        // modal loop ends.
+        response: Rc<Cell<isize>>,
+    }
+
+    define_class!(
+        // A tiny target object for the Open and Cancel buttons: it records the
+        // response code and stops the modal loop so control returns to `present`.
+        #[unsafe(super(objc2::runtime::NSObject))]
+        #[thread_kind = MainThreadOnly]
+        #[ivars = ButtonTargetIvars]
+        struct ConsentButtonTarget;
+
+        impl ConsentButtonTarget {
+            #[unsafe(method(open:))]
+            fn open(&self, _sender: Option<&AnyObject>) {
+                self.ivars().response.set(RESPONSE_OPEN);
+                stop_modal(self.mtm(), RESPONSE_OPEN);
+            }
+
+            #[unsafe(method(cancel:))]
+            fn cancel(&self, _sender: Option<&AnyObject>) {
+                self.ivars().response.set(RESPONSE_CANCEL);
+                stop_modal(self.mtm(), RESPONSE_CANCEL);
+            }
+        }
+    );
+
+    impl ConsentButtonTarget {
+        fn new(mtm: MainThreadMarker, response: Rc<Cell<isize>>) -> Retained<Self> {
+            let this = Self::alloc(mtm).set_ivars(ButtonTargetIvars { response });
+            unsafe { msg_send![super(this), init] }
+        }
+    }
+
+    fn stop_modal(mtm: MainThreadMarker, code: isize) {
+        let app = NSApplication::sharedApplication(mtm);
+        app.stopModalWithCode(code);
+    }
+
+    pub(super) fn present(
+        app_name: &str,
+        app_id: &str,
+        items: &[ConsentItem],
+    ) -> Result<ConsentChoice, UiAdapterError> {
+        let mtm = MainThreadMarker::new().ok_or_else(|| {
+            UiAdapterError::Unsupported(
+                "the consent window must be shown on the macOS main thread".to_string(),
+            )
+        })?;
+
+        let list_height = (items.len() as f64 * ROW_HEIGHT).min(MAX_LIST_HEIGHT);
+        let window_height = HEADER_HEIGHT + list_height + FOOTER_HEIGHT;
+
+        let style = NSWindowStyleMask::Titled | NSWindowStyleMask::Closable;
+        let rect = NSRect::new(
+            NSPoint::new(0.0, 0.0),
+            NSSize::new(WINDOW_WIDTH, window_height),
+        );
+        // SAFETY: NSWindow allocation and init must happen on the main thread;
+        // the MainThreadMarker above proves we are on it. The window is retained
+        // for the duration of the modal loop below.
+        let window = unsafe {
+            NSWindow::initWithContentRect_styleMask_backing_defer(
+                NSWindow::alloc(mtm),
+                rect,
+                style,
+                NSBackingStoreType::Buffered,
+                false,
+            )
+        };
+        window.setTitle(&NSString::from_str("Open with Krate"));
+        window.center();
+
+        let content = NSView::initWithFrame(NSView::alloc(mtm), rect);
+
+        // Header: app identity and a one-line explanation of the wall.
+        let header_y = window_height - HEADER_HEIGHT;
+        let title = bold_label(
+            mtm,
+            &format!("{app_name} wants to open"),
+            NSRect::new(
+                NSPoint::new(20.0, header_y + 38.0),
+                NSSize::new(WINDOW_WIDTH - 40.0, 22.0),
+            ),
+        );
+        content.addSubview(&title);
+        let subtitle = muted_label(
+            mtm,
+            &format!("{app_id} · it can only touch what you allow below"),
+            NSRect::new(
+                NSPoint::new(20.0, header_y + 14.0),
+                NSSize::new(WINDOW_WIDTH - 40.0, 18.0),
+            ),
+        );
+        content.addSubview(&subtitle);
+
+        // One checkbox per capability, with its rationale beneath.
+        let mut checkboxes: Vec<Retained<NSButton>> = Vec::with_capacity(items.len());
+        let list_top = HEADER_HEIGHT + list_height;
+        for (index, item) in items.iter().enumerate() {
+            let row_top = list_top - (index as f64 * ROW_HEIGHT);
+            let checkbox_rect = NSRect::new(
+                NSPoint::new(20.0, row_top - 22.0),
+                NSSize::new(WINDOW_WIDTH - 40.0, 20.0),
+            );
+            let label = if item.required {
+                format!("{}  (required)", item.display)
+            } else {
+                item.display.clone()
+            };
+            // SAFETY: checkbox construction needs the main thread; held above.
+            let checkbox = unsafe {
+                NSButton::checkboxWithTitle_target_action(
+                    &NSString::from_str(&label),
+                    None,
+                    None,
+                    mtm,
+                )
+            };
+            checkbox.setFrame(checkbox_rect);
+            // Required capabilities start checked; optional ones start off so
+            // the person opts in rather than out.
+            checkbox.setState(if item.required {
+                NSControlStateValueOn
+            } else {
+                NSControlStateValueOff
+            });
+            content.addSubview(&checkbox);
+            checkboxes.push(checkbox);
+
+            if !item.rationale.is_empty() {
+                let rationale = muted_label(
+                    mtm,
+                    &item.rationale,
+                    NSRect::new(
+                        NSPoint::new(38.0, row_top - 42.0),
+                        NSSize::new(WINDOW_WIDTH - 58.0, 16.0),
+                    ),
+                );
+                content.addSubview(&rationale);
+            }
+        }
+
+        // Footer: Cancel on the left, Open on the right.
+        let response = Rc::new(Cell::new(RESPONSE_CANCEL));
+        let target = ConsentButtonTarget::new(mtm, Rc::clone(&response));
+
+        // SAFETY: button construction on the main thread; target outlives the
+        // modal loop because it is held on the stack until `present` returns.
+        let open_button = unsafe {
+            NSButton::buttonWithTitle_target_action(
+                &NSString::from_str("Open"),
+                Some(&target),
+                Some(sel!(open:)),
+                mtm,
+            )
+        };
+        open_button.setFrame(NSRect::new(
+            NSPoint::new(WINDOW_WIDTH - 120.0, 16.0),
+            NSSize::new(100.0, 32.0),
+        ));
+        content.addSubview(&open_button);
+
+        let cancel_button = unsafe {
+            NSButton::buttonWithTitle_target_action(
+                &NSString::from_str("Cancel"),
+                Some(&target),
+                Some(sel!(cancel:)),
+                mtm,
+            )
+        };
+        cancel_button.setFrame(NSRect::new(
+            NSPoint::new(20.0, 16.0),
+            NSSize::new(100.0, 32.0),
+        ));
+        content.addSubview(&cancel_button);
+
+        window.setContentView(Some(&content));
+
+        let app = NSApplication::sharedApplication(mtm);
+        // Matches the crate's existing window-activation path; the replacement
+        // NSApp.activate is not yet in the pinned objc2-app-kit.
+        #[allow(deprecated)]
+        app.activateIgnoringOtherApps(true);
+        window.makeKeyAndOrderFront(None);
+
+        // Block here until a button stops the modal loop. NSModalResponse is a
+        // plain NSInteger, so this is the raw code the button set.
+        let code = app.runModalForWindow(&window);
+        window.close();
+
+        if code != RESPONSE_OPEN {
+            return Ok(ConsentChoice::Cancel);
+        }
+
+        let allowed = checkboxes
+            .iter()
+            .enumerate()
+            .filter(|(_, checkbox)| checkbox.state() == NSControlStateValueOn)
+            .map(|(index, _)| index)
+            .collect();
+        Ok(ConsentChoice::Open(allowed))
+    }
+
+    fn bold_label(mtm: MainThreadMarker, text: &str, frame: NSRect) -> Retained<NSTextField> {
+        let label = NSTextField::labelWithString(&NSString::from_str(text), mtm);
+        label.setFrame(frame);
+        let size = NSFont::systemFontSize();
+        label.setFont(Some(&NSFont::boldSystemFontOfSize(size)));
+        label
+    }
+
+    fn muted_label(mtm: MainThreadMarker, text: &str, frame: NSRect) -> Retained<NSTextField> {
+        let label = NSTextField::labelWithString(&NSString::from_str(text), mtm);
+        label.setFrame(frame);
+        label.setTextColor(Some(&NSColor::secondaryLabelColor()));
+        let small = NSFont::smallSystemFontSize();
+        label.setFont(Some(&NSFont::systemFontOfSize(small)));
+        label
+    }
+}

--- a/crates/adapter-macos/src/consent.rs
+++ b/crates/adapter-macos/src/consent.rs
@@ -251,6 +251,9 @@ mod platform {
             NSPoint::new(WINDOW_WIDTH - 120.0, 16.0),
             NSSize::new(100.0, 32.0),
         ));
+        // Return activates Open, which also renders it as the default
+        // (accent-filled) button — the standard macOS dialog affordance.
+        open_button.setKeyEquivalent(&NSString::from_str("\r"));
         content.addSubview(&open_button);
 
         let cancel_button = unsafe {
@@ -265,6 +268,8 @@ mod platform {
             NSPoint::new(20.0, 16.0),
             NSSize::new(100.0, 32.0),
         ));
+        // Escape cancels, matching every macOS dialog.
+        cancel_button.setKeyEquivalent(&NSString::from_str("\u{1b}"));
         content.addSubview(&cancel_button);
 
         window.setContentView(Some(&content));

--- a/crates/adapter-macos/src/lib.rs
+++ b/crates/adapter-macos/src/lib.rs
@@ -26,7 +26,7 @@ use std::path::Path;
 use std::time::Duration;
 
 pub use consent::{present_consent_window, ConsentChoice, ConsentItem};
-pub use open_document::wait_for_opened_documents;
+pub use open_document::{choose_document, wait_for_opened_documents};
 
 pub use appkit::{
     AppKitColor, AppKitDrawFrame, AppKitDrawSurfaceState, AppKitDrawViewSurface,
@@ -498,7 +498,8 @@ impl UiAdapter for MacosAppKitPrototypeUiAdapter {
                     placement.height,
                 )?
                 .with_clickable(placement.clickable)
-                .with_checked(placement.checked),
+                .with_checked(placement.checked)
+                .with_role(placement.role.clone()),
             );
         }
 
@@ -806,6 +807,7 @@ mod tests {
             selection: None,
             clip: None,
             clickable: false,
+            role: None,
             x: 10.0,
             y: 10.0,
             width: 100.0,

--- a/crates/adapter-macos/src/lib.rs
+++ b/crates/adapter-macos/src/lib.rs
@@ -4,6 +4,7 @@
 //! `krate-adapter-common`, while macOS-specific host wiring will land here.
 
 mod appkit;
+mod consent;
 
 use krate_adapter_common::{
     locale::{DateStyle, HostLocale, LocaleId, NumberStyle},
@@ -22,6 +23,8 @@ use std::net::ToSocketAddrs;
 use std::net::{SocketAddr, TcpStream};
 use std::path::Path;
 use std::time::Duration;
+
+pub use consent::{present_consent_window, ConsentChoice, ConsentItem};
 
 pub use appkit::{
     AppKitColor, AppKitDrawFrame, AppKitDrawSurfaceState, AppKitDrawViewSurface,

--- a/crates/adapter-macos/src/lib.rs
+++ b/crates/adapter-macos/src/lib.rs
@@ -5,6 +5,7 @@
 
 mod appkit;
 mod consent;
+mod open_document;
 
 use krate_adapter_common::{
     locale::{DateStyle, HostLocale, LocaleId, NumberStyle},
@@ -25,6 +26,7 @@ use std::path::Path;
 use std::time::Duration;
 
 pub use consent::{present_consent_window, ConsentChoice, ConsentItem};
+pub use open_document::wait_for_opened_documents;
 
 pub use appkit::{
     AppKitColor, AppKitDrawFrame, AppKitDrawSurfaceState, AppKitDrawViewSurface,

--- a/crates/adapter-macos/src/open_document.rs
+++ b/crates/adapter-macos/src/open_document.rs
@@ -13,6 +13,20 @@
 use krate_adapter_common::ui::UiAdapterError;
 use std::path::PathBuf;
 
+/// Show the native open panel filtered to `.krate`, for when Krate.app is
+/// launched with no document. Returns `None` when the person cancels.
+#[cfg(target_os = "macos")]
+pub fn choose_document() -> Result<Option<PathBuf>, UiAdapterError> {
+    platform::choose()
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn choose_document() -> Result<Option<PathBuf>, UiAdapterError> {
+    Err(UiAdapterError::Unsupported(
+        "the document picker is only available on macOS".to_string(),
+    ))
+}
+
 /// Block until macOS finishes launching us and delivers any opened documents.
 ///
 /// Returns the documents Launch Services asked us to open. An empty vec means
@@ -124,6 +138,35 @@ mod platform {
         }
     }
 
+    pub(super) fn choose() -> Result<Option<PathBuf>, UiAdapterError> {
+        use objc2_app_kit::NSOpenPanel;
+        let mtm = MainThreadMarker::new().ok_or_else(|| {
+            UiAdapterError::Unsupported(
+                "the document picker must be shown on the macOS main thread".to_string(),
+            )
+        })?;
+        let panel = NSOpenPanel::openPanel(mtm);
+        panel.setTitle(Some(&NSString::from_str("Open a Krate app")));
+        panel.setCanChooseDirectories(false);
+        panel.setAllowsMultipleSelection(false);
+        // The modern replacement (allowedContentTypes) needs the UTType stack;
+        // the deprecated extension filter does exactly what we need here.
+        #[allow(deprecated)]
+        panel.setAllowedFileTypes(Some(&objc2_foundation::NSArray::from_retained_slice(&[
+            NSString::from_str("krate"),
+        ])));
+        let response = panel.runModal();
+        // NSModalResponseOK == 1
+        if response != 1 {
+            return Ok(None);
+        }
+        let urls = panel.URLs();
+        let Some(url) = urls.to_vec().into_iter().next() else {
+            return Ok(None);
+        };
+        Ok(url.path().map(|path| PathBuf::from(path.to_string())))
+    }
+
     pub(super) fn wait(late_open: Box<dyn Fn(PathBuf)>) -> Result<Vec<PathBuf>, UiAdapterError> {
         let mtm = MainThreadMarker::new().ok_or_else(|| {
             UiAdapterError::Unsupported(
@@ -134,8 +177,7 @@ mod platform {
         let opened: SharedPaths = Rc::new(RefCell::new(Vec::new()));
         let launched = Rc::new(std::cell::Cell::new(false));
         let late: LateHandler = Rc::new(RefCell::new(Some(late_open)));
-        let delegate =
-            KrateOpenDelegate::new(mtm, Rc::clone(&opened), Rc::clone(&launched), late);
+        let delegate = KrateOpenDelegate::new(mtm, Rc::clone(&opened), Rc::clone(&launched), late);
         let app = NSApplication::sharedApplication(mtm);
         app.setDelegate(Some(ProtocolObject::from_ref(&*delegate)));
 

--- a/crates/adapter-macos/src/open_document.rs
+++ b/crates/adapter-macos/src/open_document.rs
@@ -1,0 +1,155 @@
+//! Receive the macOS open-document event (P3-OPEN-03).
+//!
+//! When Finder opens a `.krate` (double-click, or `open file.krate`), Launch
+//! Services does not pass the path in argv — it delivers an Apple event to the
+//! launched app. This module runs a minimal `NSApplication` launch sequence
+//! with a delegate that captures `application:openFiles:`, stops the loop as
+//! soon as launching finishes, and hands the captured paths back to the CLI,
+//! which then runs the ordinary consent + run flow on them.
+//!
+//! macOS-only by nature; the non-macOS build is a stub that reports
+//! unsupported, so the crate keeps compiling everywhere it is referenced.
+
+use krate_adapter_common::ui::UiAdapterError;
+use std::path::PathBuf;
+
+/// Block until macOS finishes launching us and delivers any opened documents.
+///
+/// Returns the documents Launch Services asked us to open. An empty vec means
+/// the app was launched directly (double-clicked Krate.app itself, no file).
+///
+/// `late_open` stays installed for the life of the process: if Finder sends
+/// another document to this already-running instance later (double-click while
+/// an app is open), that handler receives it. Without this, macOS shows the
+/// "Krate cannot open files in this format" alert, because the running
+/// instance would otherwise refuse the event.
+#[cfg(target_os = "macos")]
+pub fn wait_for_opened_documents(
+    late_open: Box<dyn Fn(PathBuf)>,
+) -> Result<Vec<PathBuf>, UiAdapterError> {
+    platform::wait(late_open)
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn wait_for_opened_documents(
+    _late_open: Box<dyn Fn(PathBuf)>,
+) -> Result<Vec<PathBuf>, UiAdapterError> {
+    Err(UiAdapterError::Unsupported(
+        "open-document events are only delivered on macOS".to_string(),
+    ))
+}
+
+#[cfg(target_os = "macos")]
+mod platform {
+    use krate_adapter_common::ui::UiAdapterError;
+    use objc2::rc::Retained;
+    use objc2::runtime::ProtocolObject;
+    use objc2::{define_class, msg_send, DefinedClass, MainThreadMarker, MainThreadOnly};
+    use objc2_app_kit::{NSApplication, NSApplicationDelegate};
+    use objc2_foundation::{NSArray, NSNotification, NSObject, NSObjectProtocol, NSString};
+    use std::cell::RefCell;
+    use std::path::PathBuf;
+    use std::rc::Rc;
+
+    type SharedPaths = Rc<RefCell<Vec<PathBuf>>>;
+    type LateHandler = Rc<RefCell<Option<Box<dyn Fn(PathBuf)>>>>;
+
+    struct OpenDelegateIvars {
+        opened: SharedPaths,
+        /// Set once launching finishes; later documents go to `late` instead.
+        launched: Rc<std::cell::Cell<bool>>,
+        late: LateHandler,
+    }
+
+    define_class!(
+        // SAFETY:
+        // - NSObject has no extra subclassing requirements for a passive delegate.
+        // - Main-thread-only because AppKit delivers these callbacks there.
+        #[unsafe(super = NSObject)]
+        #[thread_kind = MainThreadOnly]
+        #[ivars = OpenDelegateIvars]
+        struct KrateOpenDelegate;
+
+        // SAFETY: NSObjectProtocol has no additional safety requirements.
+        unsafe impl NSObjectProtocol for KrateOpenDelegate {}
+
+        // SAFETY: Method signatures match the generated NSApplicationDelegate
+        // protocol.
+        unsafe impl NSApplicationDelegate for KrateOpenDelegate {
+            #[unsafe(method(application:openFiles:))]
+            fn application_open_files(&self, _sender: &NSApplication, files: &NSArray<NSString>) {
+                let ivars = self.ivars();
+                if ivars.launched.get() {
+                    // This instance is already running an app; a new document
+                    // gets its own process via the installed handler.
+                    if let Some(handler) = ivars.late.borrow().as_ref() {
+                        for file in files.to_vec() {
+                            handler(PathBuf::from(file.to_string()));
+                        }
+                    }
+                    return;
+                }
+                let mut opened = ivars.opened.borrow_mut();
+                for file in files.to_vec() {
+                    opened.push(PathBuf::from(file.to_string()));
+                }
+            }
+
+            // Launch Services delivers the open event during launch, so by the
+            // time launching has finished we either have the paths or there
+            // were none. Stop the loop and give control back to the CLI.
+            #[unsafe(method(applicationDidFinishLaunching:))]
+            fn application_did_finish_launching(&self, _notification: &NSNotification) {
+                self.ivars().launched.set(true);
+                let app = NSApplication::sharedApplication(self.mtm());
+                app.stop(None);
+            }
+        }
+    );
+
+    impl KrateOpenDelegate {
+        fn new(
+            mtm: MainThreadMarker,
+            opened: SharedPaths,
+            launched: Rc<std::cell::Cell<bool>>,
+            late: LateHandler,
+        ) -> Retained<Self> {
+            let this = Self::alloc(mtm).set_ivars(OpenDelegateIvars {
+                opened,
+                launched,
+                late,
+            });
+            // SAFETY: NSObject's `init` signature is correct for a fresh allocation.
+            unsafe { msg_send![super(this), init] }
+        }
+    }
+
+    pub(super) fn wait(late_open: Box<dyn Fn(PathBuf)>) -> Result<Vec<PathBuf>, UiAdapterError> {
+        let mtm = MainThreadMarker::new().ok_or_else(|| {
+            UiAdapterError::Unsupported(
+                "open-document events must be received on the macOS main thread".to_string(),
+            )
+        })?;
+
+        let opened: SharedPaths = Rc::new(RefCell::new(Vec::new()));
+        let launched = Rc::new(std::cell::Cell::new(false));
+        let late: LateHandler = Rc::new(RefCell::new(Some(late_open)));
+        let delegate =
+            KrateOpenDelegate::new(mtm, Rc::clone(&opened), Rc::clone(&launched), late);
+        let app = NSApplication::sharedApplication(mtm);
+        app.setDelegate(Some(ProtocolObject::from_ref(&*delegate)));
+
+        // Runs the launch sequence: the odoc Apple event (if any) is delivered
+        // to the delegate, then applicationDidFinishLaunching stops the loop.
+        app.run();
+
+        // The delegate stays installed for the life of the process so a later
+        // document sent to this running instance reaches the late handler
+        // instead of being refused with an OS alert. Keeping it alive forever
+        // is intentional: one delegate per process, freed at exit.
+        std::mem::forget(delegate);
+
+        let paths = opened.borrow().clone();
+        Ok(paths)
+    }
+}

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,6 +23,12 @@ serde.workspace = true
 serde_json.workspace = true
 tracing-subscriber.workspace = true
 
+# The native consent window is macOS-only today (P3-OPEN-01). Gated by target
+# so the AppKit crate never enters Linux or Windows CLI builds; those platforms
+# fall back to the terminal consent prompt.
+[target.'cfg(target_os = "macos")'.dependencies]
+krate-adapter-macos = { path = "../adapter-macos", version = "0.1.0-dev" }
+
 [dev-dependencies]
 sha2 = "0.10.9"
 tempfile = "3.27.0"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -146,6 +146,13 @@ enum Command {
         command: ManifestCommand,
     },
 
+    /// Entry point used inside Krate.app: wait for the document Finder asked
+    /// us to open, then run it behind the consent wall. Not intended for
+    /// direct use; double-click a .krate instead.
+    #[cfg(target_os = "macos")]
+    #[command(hide = true)]
+    OpenApp,
+
     /// Pack a component and its manifest into one shareable .krate bundle.
     Pack {
         /// Path to the .wasm component.
@@ -301,6 +308,8 @@ fn run() -> Result<u8> {
             test_timezone,
             app_args,
         }),
+        #[cfg(target_os = "macos")]
+        Command::OpenApp => open_app(),
         Command::Pack {
             file,
             manifest,
@@ -724,6 +733,89 @@ fn validate_app_args(app_args: &[String]) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// The Krate.app entry point (P3-OPEN-03): receive the document Finder asked
+/// us to open, then run it through the ordinary consent + native-window flow.
+/// The sandbox root is the folder the `.krate` sits in, so an app that writes
+/// `./notes/**` keeps its data in a folder next to the document — visible,
+/// understandable, and identical to running it from a terminal in that folder.
+#[cfg(target_os = "macos")]
+fn open_app() -> Result<u8> {
+    // A document that arrives while this instance is already running an app
+    // (double-click in Finder mid-session) gets its own process, so every
+    // opened .krate behaves like its own application.
+    let late_open = Box::new(|path: PathBuf| {
+        spawn_open_run(&path);
+    });
+    let opened = krate_adapter_macos::wait_for_opened_documents(late_open)
+        .map_err(|error| anyhow::anyhow!("waiting for the opened document failed: {error}"))?;
+    // AppKit also feeds process arguments through application:openFiles:, so
+    // our own subcommand name can arrive as a "document". Only paths that
+    // actually exist on disk are documents.
+    let opened: Vec<PathBuf> = opened.into_iter().filter(|path| path.exists()).collect();
+    let Some(target) = opened.first() else {
+        eprintln!("Krate opens .krate app bundles. Double-click a .krate file to run one.");
+        return Ok(2);
+    };
+    let sandbox_root = target
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
+
+    // Several documents opened at once: the first runs in this process, the
+    // rest each get their own.
+    for extra in opened.iter().skip(1) {
+        spawn_open_run(extra);
+    }
+
+    run_component(RunRequest {
+        target: target.display().to_string(),
+        file: PathBuf::new(),
+        insecure_http: false,
+        fuel: None,
+        mem_limit: 256,
+        max_http_response_bytes: DEFAULT_MAX_HTTP_RESPONSE_BYTES,
+        http_timeout_millis: DEFAULT_HTTP_TIMEOUT_MILLIS,
+        sandbox_root,
+        manifest_path: None,
+        grants: Vec::new(),
+        auto_grant: false,
+        prompt: false,
+        consent: true,
+        native_window: true,
+        json: false,
+        dump_caps: false,
+        dump_caps_format: OutputFormat::Text,
+        log_grants: None,
+        log_grants_format: GrantLogFormat::Text,
+        test_time_millis: None,
+        test_locale: None,
+        test_timezone: None,
+        app_args: Vec::new(),
+    })
+}
+
+/// Run one opened document in its own process, mirroring what open_app does
+/// for the first document. Fire-and-forget: the child owns its own consent
+/// window and lifetime.
+#[cfg(target_os = "macos")]
+fn spawn_open_run(path: &Path) {
+    let Ok(exe) = std::env::current_exe() else {
+        return;
+    };
+    let sandbox_root = path
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
+    let _ = ProcessCommand::new(exe)
+        .arg("run")
+        .arg(path)
+        .arg("--consent")
+        .arg("--native-window")
+        .arg("--sandbox-root")
+        .arg(sandbox_root)
+        .spawn();
 }
 
 fn prompt_for_session_grants(manifest: &Manifest, policy: &SessionPolicy) -> Result<SessionPolicy> {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -754,9 +754,23 @@ fn open_app() -> Result<u8> {
     // our own subcommand name can arrive as a "document". Only paths that
     // actually exist on disk are documents.
     let opened: Vec<PathBuf> = opened.into_iter().filter(|path| path.exists()).collect();
-    let Some(target) = opened.first() else {
-        eprintln!("Krate opens .krate app bundles. Double-click a .krate file to run one.");
-        return Ok(2);
+    // Launched with no document (Krate.app opened directly): offer the native
+    // picker instead of dying silently — there is no terminal to print to.
+    let picked;
+    let target = match opened.first() {
+        Some(target) => target,
+        None => {
+            match krate_adapter_macos::choose_document()
+                .map_err(|error| anyhow::anyhow!("the document picker failed: {error}"))?
+            {
+                Some(path) => {
+                    picked = path;
+                    &picked
+                }
+                // Cancelled: quitting quietly is the correct outcome.
+                None => return Ok(0),
+            }
+        }
     };
     let sandbox_root = target
         .parent()
@@ -864,7 +878,10 @@ fn prompt_for_session_grants(manifest: &Manifest, policy: &SessionPolicy) -> Res
 /// The rich window is macOS-only for now (founder decision, 2026-07-23). On
 /// other platforms this falls back to the terminal prompt, so a `--consent` run
 /// there still works; a portable window is a later P3-OPEN slice.
-fn consent_for_session_grants(manifest: &Manifest, policy: &SessionPolicy) -> Result<SessionPolicy> {
+fn consent_for_session_grants(
+    manifest: &Manifest,
+    policy: &SessionPolicy,
+) -> Result<SessionPolicy> {
     let consent_caps = manifest
         .declared_capabilities()?
         .into_iter()
@@ -912,6 +929,10 @@ fn consent_for_session_grants(manifest: &Manifest, policy: &SessionPolicy) -> Re
 }
 
 /// One capability shown in the consent window.
+///
+/// Off macOS the native window does not exist, so nothing reads these fields
+/// there — the terminal fallback re-derives what it needs from the manifest.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 struct ConsentCapability {
     cap: Capability,
     display: String,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -82,6 +82,13 @@ enum Command {
         #[arg(long)]
         prompt: bool,
 
+        /// Ask for missing capabilities in a native consent window instead of
+        /// the terminal. macOS only today; on other platforms this falls back
+        /// to the terminal prompt. This is the path a double-clicked `.krate`
+        /// uses, where there is no terminal to answer.
+        #[arg(long)]
+        consent: bool,
+
         /// Use the opt-in native window prototype for Phase 3 GUI apps
         /// (macOS AppKit today). The default GUI path stays headless.
         #[arg(long)]
@@ -257,6 +264,7 @@ fn run() -> Result<u8> {
             grant,
             auto_grant,
             prompt,
+            consent,
             native_window,
             insecure_http,
             json,
@@ -281,6 +289,7 @@ fn run() -> Result<u8> {
             grants: grant,
             auto_grant,
             prompt,
+            consent,
             native_window,
             json,
             dump_caps,
@@ -341,6 +350,7 @@ struct RunRequest {
     grants: Vec<String>,
     auto_grant: bool,
     prompt: bool,
+    consent: bool,
     native_window: bool,
     insecure_http: bool,
     json: bool,
@@ -450,10 +460,17 @@ fn run_component(request: RunRequest) -> Result<u8> {
     let mut policy = resolve_session_policy(manifest, &request.grants, request.auto_grant)?;
 
     if let Some(manifest) = manifest {
-        let can_prompt = request.prompt || io::stdin().is_terminal();
+        let can_prompt = request.prompt || request.consent || io::stdin().is_terminal();
         let missing = policy.missing_required_for_manifest(manifest)?;
         if !missing.is_empty() && can_prompt && !request.auto_grant {
-            policy = prompt_for_session_grants(manifest, &policy)?;
+            // A double-clicked bundle asks in a native window; a terminal run
+            // asks in the terminal. The two paths fold the same grant set into
+            // the same SessionPolicy, so enforcement downstream is identical.
+            policy = if request.consent {
+                consent_for_session_grants(manifest, &policy)?
+            } else {
+                prompt_for_session_grants(manifest, &policy)?
+            };
         }
 
         let missing = policy.missing_required_for_manifest(manifest)?;
@@ -744,6 +761,126 @@ fn prompt_for_session_grants(manifest: &Manifest, policy: &SessionPolicy) -> Res
     let grants = policy.grants().iter().cloned().chain(selected);
 
     Ok(SessionPolicy::from_grants(grants))
+}
+
+/// Ask for missing capabilities in a native consent window instead of the
+/// terminal. This is the path a double-clicked `.krate` takes, where there is
+/// no terminal to answer. It mirrors `prompt_for_session_grants` exactly — same
+/// filter to non-default missing caps, same `SessionPolicy::from_grants` fold —
+/// so the native and terminal paths cannot diverge in what they enforce.
+///
+/// The rich window is macOS-only for now (founder decision, 2026-07-23). On
+/// other platforms this falls back to the terminal prompt, so a `--consent` run
+/// there still works; a portable window is a later P3-OPEN slice.
+fn consent_for_session_grants(manifest: &Manifest, policy: &SessionPolicy) -> Result<SessionPolicy> {
+    let consent_caps = manifest
+        .declared_capabilities()?
+        .into_iter()
+        .filter(|cap| !policy.allows(cap) && !cap.is_default_granted())
+        .collect::<Vec<_>>();
+
+    if consent_caps.is_empty() {
+        return Ok(policy.clone());
+    }
+
+    let requests = consent_caps
+        .iter()
+        .map(|cap| {
+            let request = manifest.capabilities.iter().find(|request| {
+                request
+                    .cap
+                    .parse::<Capability>()
+                    .ok()
+                    .as_ref()
+                    .is_some_and(|parsed| parsed == cap)
+            });
+            ConsentCapability {
+                cap: cap.clone(),
+                display: cap.to_string(),
+                rationale: request
+                    .map(|request| request.rationale.clone())
+                    .unwrap_or_default(),
+                required: request.map(|request| request.required).unwrap_or(true),
+            }
+        })
+        .collect::<Vec<_>>();
+
+    match show_consent_window(&manifest.app.name, &manifest.app.id, &requests)? {
+        ConsentOutcome::Allowed(selected) => {
+            let grants = policy.grants().iter().cloned().chain(selected);
+            Ok(SessionPolicy::from_grants(grants))
+        }
+        // Cancel leaves the policy unchanged; the missing-required check that
+        // follows this call then refuses the run with the standard denial.
+        ConsentOutcome::Cancelled => Ok(policy.clone()),
+        // No native window on this platform: fall back to the terminal prompt
+        // so `--consent` still works everywhere.
+        ConsentOutcome::Unsupported => prompt_for_session_grants(manifest, policy),
+    }
+}
+
+/// One capability shown in the consent window.
+struct ConsentCapability {
+    cap: Capability,
+    display: String,
+    rationale: String,
+    required: bool,
+}
+
+/// What the user decided in the consent window.
+///
+/// Which variants are constructed depends on the platform: macOS builds return
+/// `Allowed`/`Cancelled` from the native window and never `Unsupported`, while
+/// non-macOS builds only ever return `Unsupported`. Rather than cfg each
+/// variant, allow the unused ones per build — every variant is live on some
+/// platform.
+#[allow(dead_code)]
+enum ConsentOutcome {
+    /// They pressed Open; the vec is the capabilities they allowed.
+    Allowed(Vec<Capability>),
+    /// They pressed Cancel; nothing is granted and the run is refused.
+    Cancelled,
+    /// This platform has no native consent window; caller should fall back.
+    Unsupported,
+}
+
+#[cfg(target_os = "macos")]
+fn show_consent_window(
+    app_name: &str,
+    app_id: &str,
+    requests: &[ConsentCapability],
+) -> Result<ConsentOutcome> {
+    let items = requests
+        .iter()
+        .map(|item| krate_adapter_macos::ConsentItem {
+            display: item.display.clone(),
+            rationale: item.rationale.clone(),
+            required: item.required,
+        })
+        .collect::<Vec<_>>();
+
+    match krate_adapter_macos::present_consent_window(app_name, app_id, &items)? {
+        krate_adapter_macos::ConsentChoice::Open(allowed_indices) => {
+            let selected = allowed_indices
+                .into_iter()
+                .filter_map(|index| requests.get(index).map(|item| item.cap.clone()))
+                .collect();
+            Ok(ConsentOutcome::Allowed(selected))
+        }
+        krate_adapter_macos::ConsentChoice::Cancel => Ok(ConsentOutcome::Cancelled),
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn show_consent_window(
+    _app_name: &str,
+    _app_id: &str,
+    _requests: &[ConsentCapability],
+) -> Result<ConsentOutcome> {
+    // No native window off macOS yet; the caller falls back to the terminal
+    // prompt. This arm keeps the Linux and Windows builds compiling and is
+    // exercised on those CI lanes, closing the off-macOS-stub gap by design.
+    Ok(ConsentOutcome::Unsupported)
 }
 
 fn parse_grant_response(input: &str, caps: &[Capability]) -> Result<Vec<Capability>> {

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -31,6 +31,7 @@ krate-adapter-macos = { path = "../adapter-macos", version = "0.1.0-dev" }
 krate-adapter-windows = { path = "../adapter-windows", version = "0.1.0-dev" }
 
 [dev-dependencies]
+tempfile = "3.27.0"
 criterion.workspace = true
 wit-parser.workspace = true
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -689,9 +689,23 @@ impl LocalPhase2Adapter {
                 if let Some(err) = map_existing_broken_leaf_error(&host_path, err)? {
                     return Err(err);
                 }
-                let parent = host_path.parent().ok_or(AdapterError::InvalidPath)?;
-                let real_parent = canonicalize_path_on_host(parent).map_err(map_io_error)?;
-                ensure_path_in_sandbox(&root, &real_parent)?;
+                // Parents may be missing too: a write-mode open materializes
+                // them (see FsAdapter::open), so validate the nearest ancestor
+                // that does exist against the sandbox. The missing segments
+                // between it and the leaf came from the normalized logical
+                // path, so traversal is unrepresentable in them, and
+                // ensure_no_symlink_segments already vetted the existing ones.
+                let mut ancestor = host_path.parent().ok_or(AdapterError::InvalidPath)?;
+                let real_ancestor = loop {
+                    match canonicalize_path_on_host(ancestor) {
+                        Ok(real) => break real,
+                        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                            ancestor = ancestor.parent().ok_or(AdapterError::InvalidPath)?;
+                        }
+                        Err(err) => return Err(map_io_error(err)),
+                    }
+                };
+                ensure_path_in_sandbox(&root, &real_ancestor)?;
                 Ok(host_path)
             }
             Err(err) => Err(map_io_error(err)),
@@ -902,7 +916,7 @@ fn ensure_no_symlink_segments(
     }
 
     let mut current = root.to_path_buf();
-    for (index, segment) in segments.iter().enumerate() {
+    for segment in segments.iter() {
         current.push(segment.as_os_str());
         match symlink_metadata_on_host(&current) {
             Ok(metadata) => {
@@ -911,8 +925,12 @@ fn ensure_no_symlink_segments(
                 }
             }
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                let is_leaf = index + 1 == segments.len();
-                if is_leaf && missing_leaf == MissingLeaf::Allow {
+                // Once any segment is missing, nothing beneath it exists, so
+                // no later segment can be a symlink. When the operation may
+                // create its target (write-mode opens), the missing tail is
+                // fine: every existing segment above was already vetted, and
+                // the write path materializes the rest as real directories.
+                if missing_leaf == MissingLeaf::Allow {
                     return Ok(());
                 }
                 return Err(map_io_error(err));
@@ -1116,6 +1134,17 @@ impl FsAdapter for LocalPhase2Adapter {
             OpenMode::Write | OpenMode::ReadWrite | OpenMode::Append => FsOperation::CreateLeaf,
         };
         let path = self.resolve_fs_path(path, missing_leaf)?;
+        // A write-mode open materializes missing parent directories. The
+        // resolved path is already validated to sit inside the sandbox and the
+        // capability policy was checked before dispatch, so a grant like
+        // `fs.write:./notes/**` lets the app create that tree on first save —
+        // a shared bundle must work from a fresh folder, not only one that
+        // happens to have its directories pre-made.
+        if !matches!(mode, OpenMode::Read) {
+            if let Some(parent) = path.as_path().parent() {
+                create_dir_all_on_host(parent).map_err(map_io_error)?;
+            }
+        }
         let mut opts = std::fs::OpenOptions::new();
         apply_no_follow_final_symlink_on_host(&mut opts);
         match mode {
@@ -2073,6 +2102,32 @@ mod tests {
         let err = normalize_fs_path("fixtures/../secret.txt").expect_err("path should be rejected");
 
         assert_eq!(err, AdapterError::InvalidPath);
+    }
+
+    #[cfg(feature = "phase2-bindings")]
+    #[test]
+    fn write_open_creates_missing_parent_directories_inside_sandbox() {
+        let sandbox = tempfile::tempdir().expect("tempdir");
+        let adapter = LocalPhase2Adapter::new(
+            Rc::new(RefCell::new(OutputMode::Sink)),
+            None,
+            Some("en_US.UTF-8".to_string()),
+            Some("UTC".to_string()),
+            Vec::new(),
+            1024,
+            sandbox.path().to_path_buf(),
+        );
+
+        // A shared bundle runs from a fresh folder: nothing under the sandbox
+        // exists yet. A granted write must materialize its own directory tree.
+        let handle = FsAdapter::open(&adapter, "./notes/first.txt", OpenMode::Write)
+            .expect("write-open should create missing parent directories");
+        FsAdapter::write(&adapter, &handle, b"hello").expect("write");
+        drop(handle);
+
+        let on_disk =
+            std::fs::read_to_string(sandbox.path().join("notes/first.txt")).expect("read back");
+        assert_eq!(on_disk, "hello");
     }
 
     #[cfg(feature = "phase2-bindings")]

--- a/crates/runtime/src/phase3_gui_host.rs
+++ b/crates/runtime/src/phase3_gui_host.rs
@@ -143,6 +143,7 @@ impl Phase3GuiHost {
                 width: rect.width,
                 height: rect.height,
                 clickable,
+                role: node.role.clone(),
             });
         }
         drop(offsets);

--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -7,7 +7,7 @@ multilingual = false
 src = "src"
 
 [output.html]
-site-url = "/krate/"
+site-url = "/krate/docs/"
 git-repository-url = "https://github.com/incyashraj/krate"
 git-repository-icon = "fa-github"
 edit-url-template = "https://github.com/incyashraj/krate/edit/main/docs/book/{path}"

--- a/docs/book/src/try-krate-notes.md
+++ b/docs/book/src/try-krate-notes.md
@@ -5,6 +5,29 @@ and it can only touch the folder you allow it to.
 
 This page is written for someone who has never used Krate before.
 
+## The double-click way (macOS)
+
+The shortest path, no terminal involved:
+
+1. Download `Krate.app` from the [latest release](https://github.com/incyashraj/krate/releases/latest)
+   (the `krate-app-…-apple-darwin.zip` asset for your Mac — `aarch64` for
+   Apple silicon, `x86_64` for Intel) and unzip it.
+2. The first time only: **right-click Krate.app and choose Open.** The app is
+   not yet code-signed, so macOS warns about an unidentified developer;
+   right-click → Open is Apple's supported way past that warning. Signing is
+   on the roadmap and this step disappears with it.
+3. Download [notes.krate](https://github.com/incyashraj/krate/releases/download/notes-v0.1.0/notes.krate)
+   and double-click it.
+
+A permission window appears before anything runs: the app's identity, each
+capability it wants, and the author's reason for each — with a checkbox per
+capability. Nothing executes until you press Open, and the app gets exactly
+what you left checked, for that session only. Its notes are saved in a
+`notes/` folder next to the file, and it can touch nothing else on your Mac.
+
+Everything below is the terminal path: the same app, the same wall, and the
+way to run it on Linux and Windows today.
+
 ## What you need
 
 The Krate runtime. One command installs it on macOS and Linux:

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -1,0 +1,313 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Krate — share software like a document. It asks before it runs.</title>
+<meta name="description" content="Krate turns software created by AI into one file you can share like a document. Double-click it, see exactly what it wants to touch, and it runs natively on macOS, Windows, and Linux — touching nothing you didn't allow." />
+<meta property="og:title" content="Krate — share software like a document" />
+<meta property="og:description" content="One file. Double-click it. It shows you what it wants, then runs — and can touch nothing you didn't allow." />
+<meta property="og:type" content="website" />
+<link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAQKADAAQAAAABAAAAQAAAAABGUUKwAAAMIElEQVR4Ae1abYxcVRl+78fc2c9Yrd1SoB90l0I/wmdrpK0IBROpCkZblUhUlIiASCn9gVEBJcoPNP4RbY2JRKJIgdDEhFgtCaHQEui2RUu/2HZbtlAo/aCt3Zm5nz7PuXN3Z5Z77s7MbhXCnmY7M3fuOed9nvd53/OeM1dkrI0xMMbAGANjDHx4GTAahx4ZUx+UaaHvnxvZRkfkh3bjYzXQ0zQDM7IORZHsOVCSvXKfETYwitRNwLRfR+Nc17vBEPN6ieQCMa02w2xk6pH3iQg59PvFMLZJZDwW2eaf3lxhHK5n5LoImPSL0pdM035AbHOGYPIoCGgB3tQz5Sjeq6w3xbAsETghCsLeKPR/cvCH+T/XOkuNBETGmQ/494hp3GuIZUSBW+v4/9v7rFw8X+D98s0u5275ikEPZbaa4vaMn7v3iO3cF3meRJGPAWvkLXPq0/ClD8cgHo2cs2LS7pJ5UOSu4WYZFsmZ95/6YpRrelKCwBQVdMMN+T743jAQFjmJ/NI3Dv64+ZEsizIJGHffsXFNdvMmDNb5vpW9Bp1hgoDQOxgawcWHftT2tuY2pg59a7Kav27k8p0RpcVE9wH6o8OMXNMkKzRu0iNUuVPz9dLIiiS8AZkVcR99AP/gLz+QMJLru25/La9BKdokOPGC4hSscBdEETP+/2ud05ld2/U4bI3zTk6YNAM9/p3WS0tAFLozDKu5JQq8tH4fkGuRGHbeDv3C+XUTIGJ1IJXC+e/TNb9WF2BZtAyZqLtdr4AotBD4KvZ1nUd63UOZwuBywPNpa8AQRvRketMSkH776Fx1fRCLoT451UJVbcgL+3xyLXk7c1VubHJOlFEPagkI0cnEOsAVYLSaS49juHmTTbllviPXzc6JiYX46e2+PLTBlY37Y0k4WqsasETZr2cgY6qytaNAQAJ87mRLbl3gyLUAXin7L8y25ZqZtjy9w5ffvlBSRJD2vFa4dRBB+zM2yhkE1DFJyq0EkEh93mRbboXHr51TDbyymw0lXAsiFisiPBDhygaEBpuD0DgNwaHG1hNAAdiNhYALu0kAPX7bgnwmcGVFxX8xETkQkYMiPHno+bIiMGBeb23FCEPeQgFhhgSyh6R86giBUjlq5k0h8Ka6gA8xG8mRiqgmQikCJjFH1KyIkYQAvci/zIYb3IBKQXKbAqkvzMt1c5yqGM/sP8yXVURs9+Q3zxdlI1cN9Mtjga+difSJMhQwfBIkaAueuny6LbctbJLFs8oHEulzjeiqIgI5hHlk3W4QsT4mgrUEdr/6phSsz4JaArAHEhOds5ZBZvez20zpmmDCK54828MDE/rm9DUDaBkCneNN2XvEkN4joeSyVgvYo4cv+s2QgkAsGjyU/ednO/K5WQ5OyiDHXNkNuF/TZcSscIbE28eLkZz5EVNe6PXln7tcydGItEZj4Chd0yqAiyf8r/6ldfaxz+z8uCmfnelICZVdq2PIR1s0RqQN0OA1Lq37joby1olQLCjvjeOBBLCFIZLest2RQQCGo5x1ksZ1bLcV+IIXSb8byeFTIm15ENFsSFOiiHSr6r5Kj+87EshbJ0M1L3MPS2eGamynZkhlv14CegLQJ0JsZeCvknoizZMw9D+laNSIOIHxeocAJ/iBVvaRzk5lZEYS0BOgZqB8NBLCjJQdqzQqIGmjRcTxAqUOj0PqPgBwxasCjglzmN82M2xURg3althY+aolgKLh2DpmbahjfU9JzuuwZOH0HDKxocIhGbxRIih15XECR6IlaBODKRhlLMz6CHt5ESvPxl5PkaOzkx3L3RLTql61BOAYHJSzd3r3EBZ0tJuybmdJVm8uyJKLmuTyLqdhIujxXuXxYCDGBz0e25AA39zny9odLvKMyPhWkEMb082M7Q/1MaAnADxlrgLwzowOW+68sgVKcOXR7qI8saUoSy4mEcMpopwsW0xsmATrOaWeBjx2FtUVAmQMvKSWwmtm5eUTU3Oy5l9F+ceOWClVrh34oGMmviGTAMVqRn8yT5leihJ47pR2efl1T/66qQAioAhFRLYiThQDef1YICUcO9Lbgx4fCtyVtdtxzI08QOAXnmWr9wyDgd9qdHbqrpcJ0hJA0RhKWukj4Gci2XfYl3ewLI1vNVX8z8W2dx6J2O/Jo5uK8vjmWBGfPhdEoFBhvZA0VgxUJgEwwVVKOPF4Nwhdu6OIHy+MKuBc+ngPw4YEMkPQ1NSGLxrbDfJIKIMAemsvCFjx1AmZBykuuahZ5QSCnDvFAREOFIHQoCKYIy5pliuQI+whybISeQxcZDP6/X1HSVWYi5XHc8rjLHhI5Ek3lGdQ/W054Kn6IyZQwwAx0JuaplUA79cMqYYi0KvPz8vXLm2Wh1/sl2VPHsdq4ED6JCL29lAiHgcRS/G9UgSsZvHERlIYTt0Evh3AQe41s5sGpE7gDoCfwP3P7CoqhZ2L/LNsUats2OvKtoNew+eJmQRkKYDfsSydAPkvX9QmB94NZHV3QZY98a4s7MzriXi5HzmiH0S0yEIowgKwl/czxssen8MYTzzOtT72+N8IfJ8rBH77Fa3YB1hKIR5yUGyn4vI9/w23OcsgIP5JTA3+nmE5Z+w9zs9CqAO7wuVXVRDxOIgAwC/D4xPbrThHMDSmIjQA5NFNMRElDMBktngOPU7gLG8rpL6zKC+BIK44P7iyTQHnRowKVKfICn92Dogf5EgBgUsZBKR3GLiKiVkJ0ogiCEgj4rHufrmTRFARyAEdCREgYS7+KPk+KGfmGbYqdmLgghiH1HcW5CXl8ZwCfhY8TuBFAE8ac4Z+E5Tclf2qJ2CYUpBFydrtBZk9yZb5AMgYpVdonw9CJqBIuuuqdhUaj8HbdwwQ0QJFxPdeeLYj45o94aGGifFOYg+xDsCV1CfS4+0yALyi3E5WiZd6S/Ls7mJ5FRkkpgpyWalV1yo+aAkg/qxlkJl32xue3PTIUblsel5unN8KyefhEUPlBi5V/ZAyiVh+9SARy1YfVfctuaQFyyd+GAHwdwvI6pQ6PD5jIjyOnBIDF3h8MIU7mJRK24rHwtZsLSgF8TP3BFqc/KLRSrCCqNS3VAHHX99TRDYuynxFRJssoCJgLJMkiSiACJbNd30GRBxrkdWbTsmy1cfUfaewpG3cQ+C23LGoXcU4E9tQqbMS3NLnyppX+gHcUwUYlUDwI2laBUiAI4+MvUDlpMmPHM+9BiL2lKoUUUUEYrujzVCK6EMB8+TmfjkB798O4GePS4/xAeBb+1V9QHJyyDskH/TrPZ8YCOKogeTj0FctAZjmkBGWD/gzK4LBIflLDqdbDyI27inKZVDCjfPblOSZI5QiYE2BREAR37+iHYccvvI2E2nSYqlHshVJcs0rp6QbqwAPX3KwVpFN2dXaUNCZYXhId7uWAJz19ES+VcRTV0014h+YY0ARSFAbEB7zO5sUEZ9ijiiHBsPSQ2gwcSYhmgDf0scYp9RdJEi4glKnx4G7DujxAaJfCgIr2jlg3JA3WgJKHX37nLenvWpY9qXS4HOB/CWHBj/3WgGhQSKoiPZYEQBFJfCOJKszxp/amng8lnpMZl2wByEaMCBwe7xTxq7Bi9XvuA3Rtvwte5ZHubZfiYfDvlFo3PpyD0EivrOgHSHSJK8f9eFpeBzVYff+kloSKfVMw2q1JdcKmfX/zP3dOffqumTPc9uB8U7obsFzJpPxTK5ujLqu05ceZM+nWxeCANYNXM8TqWcbVMdUKCxwivCOGdoXF1ZOfkPXc9j5nJv3XB/Zzl9EPSvUoBTTZsdQBM3GEBgdlycTYTwbD4b5he95K7tWJVfTXoclgJ2cm3sejHKtKyAnfBpFEtIsGvE1QMq14AfL/lXe76ffwnIua0htEqzs5B7tvNv+2F5TzNxydYIxSuFQOceovGc9zSdEAT7Ih3cMB55z1qSAxDjruz3fNE3r/sh0kBNwjqWIyCQ46XoaXwHBhB8BXEL3LSMKf+qt6lxZ64R1EaAG/VbvGbZjfBuzfRUr+EwxHexhR1iP1mrt0Pt4nha6Pp4f2Q1XPuG70R/kj119Q2/L+lw/AcloS191nPHtMwK/dD40MBGhVlM4Jd1H/GqYATZrh6DIXV4J6/zD5xRHPObYAGMMjDEwxsAYAx8yBv4LciWnCBQ9POMAAAAASUVORK5CYII=" />
+<style>
+  :root {
+    --bg: #0b0e14;
+    --bg-soft: #121722;
+    --panel: #161c28;
+    --line: #232b3a;
+    --line-soft: #1b2230;
+    --ink: #eef2f8;
+    --ink-dim: #9aa7bd;
+    --ink-faint: #6b7688;
+    --blue: #2f8cff;
+    --blue-bright: #4c9dff;
+    --blue-deep: #0060d6;
+    --green: #35c07a;
+    --red: #e2564f;
+    --radius: 12px;
+    --maxw: 1080px;
+    --sans: "Krate Sans", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    --mono: "Krate Mono", ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+  }
+  * { box-sizing: border-box; }
+  html { -webkit-text-size-adjust: 100%; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--ink);
+    font-family: var(--sans);
+    font-size: 17px;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+  }
+  a { color: var(--blue-bright); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 24px; }
+
+  /* ---- top bar ---- */
+  header.bar {
+    position: sticky; top: 0; z-index: 10;
+    background: rgba(11,14,20,0.82);
+    backdrop-filter: saturate(140%) blur(8px);
+    border-bottom: 1px solid var(--line-soft);
+  }
+  .bar-inner { display: flex; align-items: center; justify-content: space-between; height: 60px; }
+  .brand { display: flex; align-items: center; gap: 10px; font-weight: 600; letter-spacing: -0.01em; }
+  .brand img { width: 26px; height: 26px; display: block; }
+  .brand span { font-size: 18px; }
+  nav.links { display: flex; gap: 22px; align-items: center; }
+  nav.links a { color: var(--ink-dim); font-size: 15px; }
+  nav.links a:hover { color: var(--ink); text-decoration: none; }
+
+  /* ---- hero ---- */
+  .hero { padding: 92px 0 60px; position: relative; overflow: hidden; }
+  .hero::before {
+    content: ""; position: absolute; inset: -40% 0 auto 0; height: 620px;
+    background: radial-gradient(60% 70% at 50% 0%, rgba(47,140,255,0.16), transparent 70%);
+    pointer-events: none;
+  }
+  .eyebrow {
+    display: inline-block; font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase;
+    color: var(--blue-bright); border: 1px solid var(--line);
+    background: var(--bg-soft); padding: 6px 12px; border-radius: 999px; margin-bottom: 26px;
+  }
+  h1.headline {
+    font-size: clamp(34px, 6vw, 62px); line-height: 1.04; letter-spacing: -0.03em;
+    font-weight: 680; margin: 0 0 22px; max-width: 15ch; text-wrap: balance;
+  }
+  h1.headline .accent { color: var(--blue-bright); }
+  .sub { font-size: clamp(17px, 2.4vw, 21px); color: var(--ink-dim); max-width: 56ch; margin: 0 0 34px; }
+  .cta-row { display: flex; flex-wrap: wrap; gap: 14px; align-items: center; }
+  .btn {
+    display: inline-flex; align-items: center; gap: 9px; font-family: var(--sans);
+    font-size: 16px; font-weight: 560; padding: 13px 22px; border-radius: 10px;
+    border: 1px solid transparent; cursor: pointer; transition: transform .06s ease, background .15s ease;
+  }
+  .btn:hover { text-decoration: none; }
+  .btn:active { transform: translateY(1px); }
+  .btn-primary { background: var(--blue); color: #fff; }
+  .btn-primary:hover { background: var(--blue-bright); }
+  .btn-ghost { background: transparent; color: var(--ink); border-color: var(--line); }
+  .btn-ghost:hover { border-color: #34405a; background: var(--bg-soft); }
+
+  .install {
+    margin-top: 30px; display: inline-flex; align-items: stretch; max-width: 100%;
+    border: 1px solid var(--line); border-radius: 10px; background: #0d1119; overflow: hidden;
+  }
+  .install code {
+    font-family: var(--mono); font-size: 14.5px; color: var(--ink); padding: 13px 16px;
+    white-space: nowrap; overflow-x: auto; display: block;
+  }
+  .install .prompt { color: var(--ink-faint); user-select: none; }
+  .copy {
+    border: none; border-left: 1px solid var(--line); background: var(--panel); color: var(--ink-dim);
+    font-family: var(--sans); font-size: 13px; padding: 0 16px; cursor: pointer;
+  }
+  .copy:hover { color: var(--ink); background: #1b2333; }
+
+  /* ---- section scaffolding ---- */
+  section { padding: 66px 0; border-top: 1px solid var(--line-soft); }
+  .kicker { font-size: 13px; letter-spacing: 0.09em; text-transform: uppercase; color: var(--ink-faint); margin: 0 0 12px; }
+  h2 { font-size: clamp(24px, 3.6vw, 34px); letter-spacing: -0.02em; margin: 0 0 16px; font-weight: 640; text-wrap: balance; }
+  .lead { color: var(--ink-dim); max-width: 60ch; font-size: 18px; margin: 0 0 40px; }
+
+  /* ---- three steps ---- */
+  .steps { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+  .step { background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius); padding: 26px 24px; }
+  .step .n { font-family: var(--mono); font-size: 13px; color: var(--blue-bright); margin-bottom: 14px; }
+  .step h3 { margin: 0 0 8px; font-size: 19px; letter-spacing: -0.01em; }
+  .step p { margin: 0; color: var(--ink-dim); font-size: 15.5px; }
+
+  /* ---- permission wall mock ---- */
+  .wall-grid { display: grid; grid-template-columns: 1.05fr 0.95fr; gap: 44px; align-items: center; }
+  .consent {
+    background: #1b1f27; border: 1px solid #2a3140; border-radius: 14px; padding: 22px 22px 18px;
+    box-shadow: 0 24px 60px -30px rgba(0,0,0,0.8); max-width: 420px;
+  }
+  .consent .title { font-weight: 600; font-size: 16px; margin: 2px 0 2px; }
+  .consent .id { color: var(--ink-faint); font-size: 13px; margin-bottom: 18px; }
+  .cap { display: flex; gap: 12px; align-items: flex-start; padding: 12px 0; border-top: 1px solid #242b38; }
+  .cap:first-of-type { border-top: none; }
+  .cap .box { width: 18px; height: 18px; border-radius: 5px; background: var(--blue); flex: 0 0 auto; margin-top: 2px; position: relative; }
+  .cap .box::after { content: "✓"; position: absolute; inset: 0; color: #fff; font-size: 12px; display: grid; place-items: center; }
+  .cap .grant { font-family: var(--mono); font-size: 13.5px; color: var(--ink); }
+  .cap .why { color: var(--ink-faint); font-size: 13px; }
+  .consent .actions { display: flex; justify-content: flex-end; gap: 10px; margin-top: 18px; }
+  .consent .b { font-size: 13.5px; padding: 8px 16px; border-radius: 8px; }
+  .consent .b.cancel { background: transparent; border: 1px solid #333c4c; color: var(--ink-dim); }
+  .consent .b.open { background: var(--blue); color: #fff; border: 1px solid var(--blue); }
+  .wall-copy h2 { margin-bottom: 14px; }
+  .wall-copy p { color: var(--ink-dim); margin: 0 0 14px; }
+  .wall-copy .pt { display: flex; gap: 10px; align-items: baseline; margin: 10px 0; font-size: 15.5px; }
+  .wall-copy .pt b { color: var(--ink); font-weight: 560; }
+  .dot { width: 7px; height: 7px; border-radius: 999px; flex: 0 0 auto; margin-top: 7px; }
+  .dot.g { background: var(--green); }
+  .dot.r { background: var(--red); }
+
+  /* ---- proof ---- */
+  .proof { background: var(--bg-soft); border: 1px solid var(--line); border-radius: var(--radius); padding: 30px 30px; }
+  .proof p { margin: 0; color: var(--ink-dim); font-size: 17px; }
+  .proof b { color: var(--ink); font-weight: 560; }
+  .proof .mono { font-family: var(--mono); color: var(--blue-bright); font-size: 15px; }
+
+  /* ---- who it's for ---- */
+  .cols { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
+  .card { background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius); padding: 24px; }
+  .card h3 { margin: 0 0 8px; font-size: 18px; }
+  .card p { margin: 0; color: var(--ink-dim); font-size: 15.5px; }
+
+  /* ---- footer ---- */
+  footer { border-top: 1px solid var(--line-soft); padding: 40px 0 60px; color: var(--ink-faint); font-size: 14px; }
+  .foot-inner { display: flex; flex-wrap: wrap; gap: 20px; justify-content: space-between; align-items: center; }
+  .foot-links { display: flex; gap: 20px; flex-wrap: wrap; }
+  .foot-links a { color: var(--ink-dim); }
+
+  @media (max-width: 820px) {
+    .steps { grid-template-columns: 1fr; }
+    .wall-grid { grid-template-columns: 1fr; gap: 30px; }
+    .cols { grid-template-columns: 1fr; }
+    nav.links a:not(.gh) { display: none; }
+  }
+</style>
+</head>
+<body>
+
+<header class="bar">
+  <div class="wrap bar-inner">
+    <div class="brand"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAQKADAAQAAAABAAAAQAAAAABGUUKwAAAMIElEQVR4Ae1abYxcVRl+78fc2c9Yrd1SoB90l0I/wmdrpK0IBROpCkZblUhUlIiASCn9gVEBJcoPNP4RbY2JRKJIgdDEhFgtCaHQEui2RUu/2HZbtlAo/aCt3Zm5nz7PuXN3Z5Z77s7MbhXCnmY7M3fuOed9nvd53/OeM1dkrI0xMMbAGANjDHx4GTAahx4ZUx+UaaHvnxvZRkfkh3bjYzXQ0zQDM7IORZHsOVCSvXKfETYwitRNwLRfR+Nc17vBEPN6ieQCMa02w2xk6pH3iQg59PvFMLZJZDwW2eaf3lxhHK5n5LoImPSL0pdM035AbHOGYPIoCGgB3tQz5Sjeq6w3xbAsETghCsLeKPR/cvCH+T/XOkuNBETGmQ/494hp3GuIZUSBW+v4/9v7rFw8X+D98s0u5275ikEPZbaa4vaMn7v3iO3cF3meRJGPAWvkLXPq0/ClD8cgHo2cs2LS7pJ5UOSu4WYZFsmZ95/6YpRrelKCwBQVdMMN+T743jAQFjmJ/NI3Dv64+ZEsizIJGHffsXFNdvMmDNb5vpW9Bp1hgoDQOxgawcWHftT2tuY2pg59a7Kav27k8p0RpcVE9wH6o8OMXNMkKzRu0iNUuVPz9dLIiiS8AZkVcR99AP/gLz+QMJLru25/La9BKdokOPGC4hSscBdEETP+/2ud05ld2/U4bI3zTk6YNAM9/p3WS0tAFLozDKu5JQq8tH4fkGuRGHbeDv3C+XUTIGJ1IJXC+e/TNb9WF2BZtAyZqLtdr4AotBD4KvZ1nUd63UOZwuBywPNpa8AQRvRketMSkH776Fx1fRCLoT451UJVbcgL+3xyLXk7c1VubHJOlFEPagkI0cnEOsAVYLSaS49juHmTTbllviPXzc6JiYX46e2+PLTBlY37Y0k4WqsasETZr2cgY6qytaNAQAJ87mRLbl3gyLUAXin7L8y25ZqZtjy9w5ffvlBSRJD2vFa4dRBB+zM2yhkE1DFJyq0EkEh93mRbboXHr51TDbyymw0lXAsiFisiPBDhygaEBpuD0DgNwaHG1hNAAdiNhYALu0kAPX7bgnwmcGVFxX8xETkQkYMiPHno+bIiMGBeb23FCEPeQgFhhgSyh6R86giBUjlq5k0h8Ka6gA8xG8mRiqgmQikCJjFH1KyIkYQAvci/zIYb3IBKQXKbAqkvzMt1c5yqGM/sP8yXVURs9+Q3zxdlI1cN9Mtjga+difSJMhQwfBIkaAueuny6LbctbJLFs8oHEulzjeiqIgI5hHlk3W4QsT4mgrUEdr/6phSsz4JaArAHEhOds5ZBZvez20zpmmDCK54828MDE/rm9DUDaBkCneNN2XvEkN4joeSyVgvYo4cv+s2QgkAsGjyU/ednO/K5WQ5OyiDHXNkNuF/TZcSscIbE28eLkZz5EVNe6PXln7tcydGItEZj4Chd0yqAiyf8r/6ldfaxz+z8uCmfnelICZVdq2PIR1s0RqQN0OA1Lq37joby1olQLCjvjeOBBLCFIZLest2RQQCGo5x1ksZ1bLcV+IIXSb8byeFTIm15ENFsSFOiiHSr6r5Kj+87EshbJ0M1L3MPS2eGamynZkhlv14CegLQJ0JsZeCvknoizZMw9D+laNSIOIHxeocAJ/iBVvaRzk5lZEYS0BOgZqB8NBLCjJQdqzQqIGmjRcTxAqUOj0PqPgBwxasCjglzmN82M2xURg3althY+aolgKLh2DpmbahjfU9JzuuwZOH0HDKxocIhGbxRIih15XECR6IlaBODKRhlLMz6CHt5ESvPxl5PkaOzkx3L3RLTql61BOAYHJSzd3r3EBZ0tJuybmdJVm8uyJKLmuTyLqdhIujxXuXxYCDGBz0e25AA39zny9odLvKMyPhWkEMb082M7Q/1MaAnADxlrgLwzowOW+68sgVKcOXR7qI8saUoSy4mEcMpopwsW0xsmATrOaWeBjx2FtUVAmQMvKSWwmtm5eUTU3Oy5l9F+ceOWClVrh34oGMmviGTAMVqRn8yT5leihJ47pR2efl1T/66qQAioAhFRLYiThQDef1YICUcO9Lbgx4fCtyVtdtxzI08QOAXnmWr9wyDgd9qdHbqrpcJ0hJA0RhKWukj4Gci2XfYl3ewLI1vNVX8z8W2dx6J2O/Jo5uK8vjmWBGfPhdEoFBhvZA0VgxUJgEwwVVKOPF4Nwhdu6OIHy+MKuBc+ngPw4YEMkPQ1NSGLxrbDfJIKIMAemsvCFjx1AmZBykuuahZ5QSCnDvFAREOFIHQoCKYIy5pliuQI+whybISeQxcZDP6/X1HSVWYi5XHc8rjLHhI5Ek3lGdQ/W054Kn6IyZQwwAx0JuaplUA79cMqYYi0KvPz8vXLm2Wh1/sl2VPHsdq4ED6JCL29lAiHgcRS/G9UgSsZvHERlIYTt0Evh3AQe41s5sGpE7gDoCfwP3P7CoqhZ2L/LNsUats2OvKtoNew+eJmQRkKYDfsSydAPkvX9QmB94NZHV3QZY98a4s7MzriXi5HzmiH0S0yEIowgKwl/czxssen8MYTzzOtT72+N8IfJ8rBH77Fa3YB1hKIR5yUGyn4vI9/w23OcsgIP5JTA3+nmE5Z+w9zs9CqAO7wuVXVRDxOIgAwC/D4xPbrThHMDSmIjQA5NFNMRElDMBktngOPU7gLG8rpL6zKC+BIK44P7iyTQHnRowKVKfICn92Dogf5EgBgUsZBKR3GLiKiVkJ0ogiCEgj4rHufrmTRFARyAEdCREgYS7+KPk+KGfmGbYqdmLgghiH1HcW5CXl8ZwCfhY8TuBFAE8ac4Z+E5Tclf2qJ2CYUpBFydrtBZk9yZb5AMgYpVdonw9CJqBIuuuqdhUaj8HbdwwQ0QJFxPdeeLYj45o94aGGifFOYg+xDsCV1CfS4+0yALyi3E5WiZd6S/Ls7mJ5FRkkpgpyWalV1yo+aAkg/qxlkJl32xue3PTIUblsel5unN8KyefhEUPlBi5V/ZAyiVh+9SARy1YfVfctuaQFyyd+GAHwdwvI6pQ6PD5jIjyOnBIDF3h8MIU7mJRK24rHwtZsLSgF8TP3BFqc/KLRSrCCqNS3VAHHX99TRDYuynxFRJssoCJgLJMkiSiACJbNd30GRBxrkdWbTsmy1cfUfaewpG3cQ+C23LGoXcU4E9tQqbMS3NLnyppX+gHcUwUYlUDwI2laBUiAI4+MvUDlpMmPHM+9BiL2lKoUUUUEYrujzVCK6EMB8+TmfjkB798O4GePS4/xAeBb+1V9QHJyyDskH/TrPZ8YCOKogeTj0FctAZjmkBGWD/gzK4LBIflLDqdbDyI27inKZVDCjfPblOSZI5QiYE2BREAR37+iHYccvvI2E2nSYqlHshVJcs0rp6QbqwAPX3KwVpFN2dXaUNCZYXhId7uWAJz19ES+VcRTV0014h+YY0ARSFAbEB7zO5sUEZ9ijiiHBsPSQ2gwcSYhmgDf0scYp9RdJEi4glKnx4G7DujxAaJfCgIr2jlg3JA3WgJKHX37nLenvWpY9qXS4HOB/CWHBj/3WgGhQSKoiPZYEQBFJfCOJKszxp/amng8lnpMZl2wByEaMCBwe7xTxq7Bi9XvuA3Rtvwte5ZHubZfiYfDvlFo3PpyD0EivrOgHSHSJK8f9eFpeBzVYff+kloSKfVMw2q1JdcKmfX/zP3dOffqumTPc9uB8U7obsFzJpPxTK5ujLqu05ceZM+nWxeCANYNXM8TqWcbVMdUKCxwivCOGdoXF1ZOfkPXc9j5nJv3XB/Zzl9EPSvUoBTTZsdQBM3GEBgdlycTYTwbD4b5he95K7tWJVfTXoclgJ2cm3sejHKtKyAnfBpFEtIsGvE1QMq14AfL/lXe76ffwnIua0htEqzs5B7tvNv+2F5TzNxydYIxSuFQOceovGc9zSdEAT7Ih3cMB55z1qSAxDjruz3fNE3r/sh0kBNwjqWIyCQ46XoaXwHBhB8BXEL3LSMKf+qt6lxZ64R1EaAG/VbvGbZjfBuzfRUr+EwxHexhR1iP1mrt0Pt4nha6Pp4f2Q1XPuG70R/kj119Q2/L+lw/AcloS191nPHtMwK/dD40MBGhVlM4Jd1H/GqYATZrh6DIXV4J6/zD5xRHPObYAGMMjDEwxsAYAx8yBv4LciWnCBQ9POMAAAAASUVORK5CYII=" alt="" /><span>Krate</span></div>
+    <nav class="links">
+      <a href="./docs/">Docs</a>
+      <a href="./docs/try-krate-notes.html">Try it</a>
+      <a class="gh" href="https://github.com/incyashraj/krate">GitHub</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+  <section class="hero">
+    <div class="wrap">
+      <span class="eyebrow">A runtime for software created by AI</span>
+      <h1 class="headline">Share software like a document. <span class="accent">It asks before it runs.</span></h1>
+      <p class="sub">An agent packages an app as one file. You send it — or a link. The person double-clicks it, sees exactly what it wants to touch, and it runs natively on macOS, Windows, and Linux. It can touch nothing they didn't allow.</p>
+      <div class="cta-row">
+        <a class="btn btn-primary" href="https://github.com/incyashraj/krate/releases/latest">Download Krate</a>
+        <a class="btn btn-ghost" href="./docs/try-krate-notes.html">See it in two minutes →</a>
+      </div>
+      <div class="install" title="Install the runtime">
+        <code><span class="prompt">$ </span>curl -fsSL https://raw.githubusercontent.com/incyashraj/krate/main/scripts/install.sh | sh</code>
+        <button class="copy" id="copyBtn">Copy</button>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <div class="wrap">
+      <p class="kicker">How it works</p>
+      <h2>From an agent's output to a running app — in three steps.</h2>
+      <p class="lead">No installer to build, no operating system to pick, no source tree to trust. The file carries the app and its permissions together.</p>
+      <div class="steps">
+        <div class="step">
+          <div class="n">01</div>
+          <h3>Get one file</h3>
+          <p>An agent packages its output as a single <code>.krate</code> — the app plus the exact permissions it needs. Share it like any document, or link to it.</p>
+        </div>
+        <div class="step">
+          <div class="n">02</div>
+          <h3>Double-click it</h3>
+          <p>A window shows who's asking and everything it wants to touch — one folder, say. Nothing runs until you click Open. No terminal required.</p>
+        </div>
+        <div class="step">
+          <div class="n">03</div>
+          <h3>It runs, sandboxed</h3>
+          <p>The same file runs natively on macOS, Windows, and Linux. It starts with zero authority and gets only what you granted — nothing else on your machine is reachable.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <div class="wrap wall-grid">
+      <div>
+        <div class="consent" role="img" aria-label="A permission window showing an app named Krate Notes requesting read and write access to one notes folder, with Open and Cancel buttons.">
+          <div class="title">Krate Notes wants to open</div>
+          <div class="id">dev.krate.notes · it can only touch what you allow below</div>
+          <div class="cap"><span class="box"></span><div><div class="grant">fs.read:notes/**</div><div class="why">Load your saved notes</div></div></div>
+          <div class="cap"><span class="box"></span><div><div class="grant">fs.write:notes/**</div><div class="why">Save the note you are editing</div></div></div>
+          <div class="actions"><span class="b cancel">Cancel</span><span class="b open">Open</span></div>
+        </div>
+      </div>
+      <div class="wall-copy">
+        <p class="kicker">The permission wall</p>
+        <h2>Every capability is granted, never assumed.</h2>
+        <p>Software has always run with your full authority — every file, every credential, the whole network. That was a shaky default when a person wrote the code. When an agent writes it and nobody reads it, it stops being defensible.</p>
+        <div class="pt"><span class="dot g"></span><span><b>Grant</b> — the app gets exactly the capabilities you approve, for that session only.</span></div>
+        <div class="pt"><span class="dot r"></span><span><b>Deny</b> — a withheld capability stops the app before a single line of its code runs, and returns a structured answer an agent can act on.</span></div>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <div class="wrap">
+      <div class="proof">
+        <p class="kicker" style="margin-bottom:14px;">Proof, not promises</p>
+        <p>Every push, a machine nobody has logged into opens the app, clicks it, types into it, withholds a permission to confirm it refuses to start, and photographs the screen — on <b>macOS, Windows, and Linux</b>. It's all public CI. <span class="mono">the same file, on every OS, unchanged.</span></p>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <div class="wrap">
+      <p class="kicker">Who it's for</p>
+      <h2>Built for the moment software started writing itself.</h2>
+      <div class="cols" style="margin-top:28px;">
+        <div class="card">
+          <h3>Agent platforms</h3>
+          <p>Your agents generate apps your users can't safely run on their own machines, so they stay trapped in cloud sandboxes and browser previews. Krate is the layer that lets you ship them locally, behind an enforced permission wall.</p>
+        </div>
+        <div class="card">
+          <h3>Anyone sharing a tool</h3>
+          <p>Send a colleague a small tool the way you'd send a doc. They open it, see what it wants, and use it — without installing anything or trusting code they can't read.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <div class="wrap" style="text-align:center;">
+      <h2 style="margin:0 auto 16px; max-width:20ch;">Try the sample app right now.</h2>
+      <p class="lead" style="margin:0 auto 30px;">Download the runtime, grab one 13&nbsp;KB file, and double-click it. Two minutes, start to finish.</p>
+      <div class="cta-row" style="justify-content:center;">
+        <a class="btn btn-primary" href="./docs/try-krate-notes.html">Get started</a>
+        <a class="btn btn-ghost" href="https://github.com/incyashraj/krate">Read the source</a>
+      </div>
+    </div>
+  </section>
+</main>
+
+<footer>
+  <div class="wrap foot-inner">
+    <div class="brand" style="font-size:15px; color:var(--ink-dim);"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAQKADAAQAAAABAAAAQAAAAABGUUKwAAAMIElEQVR4Ae1abYxcVRl+78fc2c9Yrd1SoB90l0I/wmdrpK0IBROpCkZblUhUlIiASCn9gVEBJcoPNP4RbY2JRKJIgdDEhFgtCaHQEui2RUu/2HZbtlAo/aCt3Zm5nz7PuXN3Z5Z77s7MbhXCnmY7M3fuOed9nvd53/OeM1dkrI0xMMbAGANjDHx4GTAahx4ZUx+UaaHvnxvZRkfkh3bjYzXQ0zQDM7IORZHsOVCSvXKfETYwitRNwLRfR+Nc17vBEPN6ieQCMa02w2xk6pH3iQg59PvFMLZJZDwW2eaf3lxhHK5n5LoImPSL0pdM035AbHOGYPIoCGgB3tQz5Sjeq6w3xbAsETghCsLeKPR/cvCH+T/XOkuNBETGmQ/494hp3GuIZUSBW+v4/9v7rFw8X+D98s0u5275ikEPZbaa4vaMn7v3iO3cF3meRJGPAWvkLXPq0/ClD8cgHo2cs2LS7pJ5UOSu4WYZFsmZ95/6YpRrelKCwBQVdMMN+T743jAQFjmJ/NI3Dv64+ZEsizIJGHffsXFNdvMmDNb5vpW9Bp1hgoDQOxgawcWHftT2tuY2pg59a7Kav27k8p0RpcVE9wH6o8OMXNMkKzRu0iNUuVPz9dLIiiS8AZkVcR99AP/gLz+QMJLru25/La9BKdokOPGC4hSscBdEETP+/2ud05ld2/U4bI3zTk6YNAM9/p3WS0tAFLozDKu5JQq8tH4fkGuRGHbeDv3C+XUTIGJ1IJXC+e/TNb9WF2BZtAyZqLtdr4AotBD4KvZ1nUd63UOZwuBywPNpa8AQRvRketMSkH776Fx1fRCLoT451UJVbcgL+3xyLXk7c1VubHJOlFEPagkI0cnEOsAVYLSaS49juHmTTbllviPXzc6JiYX46e2+PLTBlY37Y0k4WqsasETZr2cgY6qytaNAQAJ87mRLbl3gyLUAXin7L8y25ZqZtjy9w5ffvlBSRJD2vFa4dRBB+zM2yhkE1DFJyq0EkEh93mRbboXHr51TDbyymw0lXAsiFisiPBDhygaEBpuD0DgNwaHG1hNAAdiNhYALu0kAPX7bgnwmcGVFxX8xETkQkYMiPHno+bIiMGBeb23FCEPeQgFhhgSyh6R86giBUjlq5k0h8Ka6gA8xG8mRiqgmQikCJjFH1KyIkYQAvci/zIYb3IBKQXKbAqkvzMt1c5yqGM/sP8yXVURs9+Q3zxdlI1cN9Mtjga+difSJMhQwfBIkaAueuny6LbctbJLFs8oHEulzjeiqIgI5hHlk3W4QsT4mgrUEdr/6phSsz4JaArAHEhOds5ZBZvez20zpmmDCK54828MDE/rm9DUDaBkCneNN2XvEkN4joeSyVgvYo4cv+s2QgkAsGjyU/ednO/K5WQ5OyiDHXNkNuF/TZcSscIbE28eLkZz5EVNe6PXln7tcydGItEZj4Chd0yqAiyf8r/6ldfaxz+z8uCmfnelICZVdq2PIR1s0RqQN0OA1Lq37joby1olQLCjvjeOBBLCFIZLest2RQQCGo5x1ksZ1bLcV+IIXSb8byeFTIm15ENFsSFOiiHSr6r5Kj+87EshbJ0M1L3MPS2eGamynZkhlv14CegLQJ0JsZeCvknoizZMw9D+laNSIOIHxeocAJ/iBVvaRzk5lZEYS0BOgZqB8NBLCjJQdqzQqIGmjRcTxAqUOj0PqPgBwxasCjglzmN82M2xURg3althY+aolgKLh2DpmbahjfU9JzuuwZOH0HDKxocIhGbxRIih15XECR6IlaBODKRhlLMz6CHt5ESvPxl5PkaOzkx3L3RLTql61BOAYHJSzd3r3EBZ0tJuybmdJVm8uyJKLmuTyLqdhIujxXuXxYCDGBz0e25AA39zny9odLvKMyPhWkEMb082M7Q/1MaAnADxlrgLwzowOW+68sgVKcOXR7qI8saUoSy4mEcMpopwsW0xsmATrOaWeBjx2FtUVAmQMvKSWwmtm5eUTU3Oy5l9F+ceOWClVrh34oGMmviGTAMVqRn8yT5leihJ47pR2efl1T/66qQAioAhFRLYiThQDef1YICUcO9Lbgx4fCtyVtdtxzI08QOAXnmWr9wyDgd9qdHbqrpcJ0hJA0RhKWukj4Gci2XfYl3ewLI1vNVX8z8W2dx6J2O/Jo5uK8vjmWBGfPhdEoFBhvZA0VgxUJgEwwVVKOPF4Nwhdu6OIHy+MKuBc+ngPw4YEMkPQ1NSGLxrbDfJIKIMAemsvCFjx1AmZBykuuahZ5QSCnDvFAREOFIHQoCKYIy5pliuQI+whybISeQxcZDP6/X1HSVWYi5XHc8rjLHhI5Ek3lGdQ/W054Kn6IyZQwwAx0JuaplUA79cMqYYi0KvPz8vXLm2Wh1/sl2VPHsdq4ED6JCL29lAiHgcRS/G9UgSsZvHERlIYTt0Evh3AQe41s5sGpE7gDoCfwP3P7CoqhZ2L/LNsUats2OvKtoNew+eJmQRkKYDfsSydAPkvX9QmB94NZHV3QZY98a4s7MzriXi5HzmiH0S0yEIowgKwl/czxssen8MYTzzOtT72+N8IfJ8rBH77Fa3YB1hKIR5yUGyn4vI9/w23OcsgIP5JTA3+nmE5Z+w9zs9CqAO7wuVXVRDxOIgAwC/D4xPbrThHMDSmIjQA5NFNMRElDMBktngOPU7gLG8rpL6zKC+BIK44P7iyTQHnRowKVKfICn92Dogf5EgBgUsZBKR3GLiKiVkJ0ogiCEgj4rHufrmTRFARyAEdCREgYS7+KPk+KGfmGbYqdmLgghiH1HcW5CXl8ZwCfhY8TuBFAE8ac4Z+E5Tclf2qJ2CYUpBFydrtBZk9yZb5AMgYpVdonw9CJqBIuuuqdhUaj8HbdwwQ0QJFxPdeeLYj45o94aGGifFOYg+xDsCV1CfS4+0yALyi3E5WiZd6S/Ls7mJ5FRkkpgpyWalV1yo+aAkg/qxlkJl32xue3PTIUblsel5unN8KyefhEUPlBi5V/ZAyiVh+9SARy1YfVfctuaQFyyd+GAHwdwvI6pQ6PD5jIjyOnBIDF3h8MIU7mJRK24rHwtZsLSgF8TP3BFqc/KLRSrCCqNS3VAHHX99TRDYuynxFRJssoCJgLJMkiSiACJbNd30GRBxrkdWbTsmy1cfUfaewpG3cQ+C23LGoXcU4E9tQqbMS3NLnyppX+gHcUwUYlUDwI2laBUiAI4+MvUDlpMmPHM+9BiL2lKoUUUUEYrujzVCK6EMB8+TmfjkB798O4GePS4/xAeBb+1V9QHJyyDskH/TrPZ8YCOKogeTj0FctAZjmkBGWD/gzK4LBIflLDqdbDyI27inKZVDCjfPblOSZI5QiYE2BREAR37+iHYccvvI2E2nSYqlHshVJcs0rp6QbqwAPX3KwVpFN2dXaUNCZYXhId7uWAJz19ES+VcRTV0014h+YY0ARSFAbEB7zO5sUEZ9ijiiHBsPSQ2gwcSYhmgDf0scYp9RdJEi4glKnx4G7DujxAaJfCgIr2jlg3JA3WgJKHX37nLenvWpY9qXS4HOB/CWHBj/3WgGhQSKoiPZYEQBFJfCOJKszxp/amng8lnpMZl2wByEaMCBwe7xTxq7Bi9XvuA3Rtvwte5ZHubZfiYfDvlFo3PpyD0EivrOgHSHSJK8f9eFpeBzVYff+kloSKfVMw2q1JdcKmfX/zP3dOffqumTPc9uB8U7obsFzJpPxTK5ujLqu05ceZM+nWxeCANYNXM8TqWcbVMdUKCxwivCOGdoXF1ZOfkPXc9j5nJv3XB/Zzl9EPSvUoBTTZsdQBM3GEBgdlycTYTwbD4b5he95K7tWJVfTXoclgJ2cm3sejHKtKyAnfBpFEtIsGvE1QMq14AfL/lXe76ffwnIua0htEqzs5B7tvNv+2F5TzNxydYIxSuFQOceovGc9zSdEAT7Ih3cMB55z1qSAxDjruz3fNE3r/sh0kBNwjqWIyCQ46XoaXwHBhB8BXEL3LSMKf+qt6lxZ64R1EaAG/VbvGbZjfBuzfRUr+EwxHexhR1iP1mrt0Pt4nha6Pp4f2Q1XPuG70R/kj119Q2/L+lw/AcloS191nPHtMwK/dD40MBGhVlM4Jd1H/GqYATZrh6DIXV4J6/zD5xRHPObYAGMMjDEwxsAYAx8yBv4LciWnCBQ9POMAAAAASUVORK5CYII=" alt="" style="width:20px;height:20px;opacity:.9;" /><span>Krate · by Krate Labs</span></div>
+    <div class="foot-links">
+      <a href="./docs/">Documentation</a>
+      <a href="https://github.com/incyashraj/krate">GitHub</a>
+      <a href="https://github.com/incyashraj/krate/releases/latest">Releases</a>
+    </div>
+  </div>
+</footer>
+
+<script>
+  (function () {
+    var btn = document.getElementById('copyBtn');
+    if (!btn) return;
+    btn.addEventListener('click', function () {
+      var cmd = 'curl -fsSL https://raw.githubusercontent.com/incyashraj/krate/main/scripts/install.sh | sh';
+      navigator.clipboard.writeText(cmd).then(function () {
+        var prev = btn.textContent; btn.textContent = 'Copied';
+        setTimeout(function () { btn.textContent = prev; }, 1400);
+      }).catch(function () {});
+    });
+  })();
+</script>
+</body>
+</html>

--- a/scripts/make-app-icon.py
+++ b/scripts/make-app-icon.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Generate Krate.icns — the macOS app icon.
+
+A macOS-style rounded square in Krate accent blue carrying a white isometric
+crate. Deterministic output so the icon can be regenerated from source rather
+than checked in as an opaque binary.
+
+Usage: python3 scripts/make-app-icon.py [output-dir]   (default: dist/icon)
+Requires PIL and /usr/bin/iconutil (macOS).
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+from PIL import Image, ImageDraw
+
+SIZE = 1024
+# macOS icon grid: the visible tile is inset from the canvas.
+TILE_INSET = 100
+CORNER_RADIUS = 185
+
+# Krate accent, light at the top to a deeper blue at the bottom.
+TOP_COLOR = (30, 140, 255)
+BOTTOM_COLOR = (0, 96, 214)
+
+
+def rounded_tile_mask() -> Image.Image:
+    mask = Image.new("L", (SIZE, SIZE), 0)
+    draw = ImageDraw.Draw(mask)
+    draw.rounded_rectangle(
+        [TILE_INSET, TILE_INSET, SIZE - TILE_INSET, SIZE - TILE_INSET],
+        radius=CORNER_RADIUS,
+        fill=255,
+    )
+    return mask
+
+
+def gradient_background() -> Image.Image:
+    background = Image.new("RGB", (SIZE, SIZE), TOP_COLOR)
+    draw = ImageDraw.Draw(background)
+    for y in range(SIZE):
+        t = y / (SIZE - 1)
+        color = tuple(
+            round(top + (bottom - top) * t)
+            for top, bottom in zip(TOP_COLOR, BOTTOM_COLOR)
+        )
+        draw.line([(0, y), (SIZE, y)], fill=color)
+    return background
+
+
+def draw_crate(draw: ImageDraw.ImageDraw) -> None:
+    """A white isometric crate: top, left and right faces, with slat gaps."""
+    cx = SIZE // 2
+    top_y = 310
+    half_w = 268
+    half_h = 134
+    depth = 250
+
+    north = (cx, top_y)
+    east = (cx + half_w, top_y + half_h)
+    south = (cx, top_y + 2 * half_h)
+    west = (cx - half_w, top_y + half_h)
+
+    east_low = (east[0], east[1] + depth)
+    south_low = (south[0], south[1] + depth)
+    west_low = (west[0], west[1] + depth)
+
+    white = (255, 255, 255, 255)
+    left_shade = (255, 255, 255, 216)
+    right_shade = (255, 255, 255, 178)
+
+    draw.polygon([north, east, south, west], fill=white)
+    draw.polygon([west, south, south_low, west_low], fill=left_shade)
+    draw.polygon([south, east, east_low, south_low], fill=right_shade)
+
+    # Slat gaps: two lines per side face, parallel to the face's top edge, so
+    # the box reads as a wooden crate rather than a plain cube.
+    gap_width = 14
+    for fraction in (0.38, 0.66):
+        offset = round(depth * fraction)
+        draw.line(
+            [
+                (west[0], west[1] + offset),
+                (south[0], south[1] + offset),
+            ],
+            fill=(0, 0, 0, 0),
+            width=gap_width,
+        )
+        draw.line(
+            [
+                (south[0], south[1] + offset),
+                (east[0], east[1] + offset),
+            ],
+            fill=(0, 0, 0, 0),
+            width=gap_width,
+        )
+    # A seam across the top face, hinting at a lid.
+    draw.line([west, east], fill=(0, 0, 0, 0), width=gap_width)
+
+
+def draw_crate_scaled(draw: ImageDraw.ImageDraw, cx: int, cy: int, scale: float,
+                      face, left, right, gap_color) -> None:
+    """The crate glyph at an arbitrary center and scale, in given colors."""
+    half_w = round(268 * scale)
+    half_h = round(134 * scale)
+    depth = round(250 * scale)
+    top_y = cy - half_h - depth // 2
+
+    north = (cx, top_y)
+    east = (cx + half_w, top_y + half_h)
+    south = (cx, top_y + 2 * half_h)
+    west = (cx - half_w, top_y + half_h)
+    east_low = (east[0], east[1] + depth)
+    south_low = (south[0], south[1] + depth)
+    west_low = (west[0], west[1] + depth)
+
+    draw.polygon([north, east, south, west], fill=face)
+    draw.polygon([west, south, south_low, west_low], fill=left)
+    draw.polygon([south, east, east_low, south_low], fill=right)
+
+    gap_width = max(6, round(14 * scale))
+    for fraction in (0.38, 0.66):
+        offset = round(depth * fraction)
+        draw.line([(west[0], west[1] + offset), (south[0], south[1] + offset)],
+                  fill=gap_color, width=gap_width)
+        draw.line([(south[0], south[1] + offset), (east[0], east[1] + offset)],
+                  fill=gap_color, width=gap_width)
+    draw.line([west, east], fill=gap_color, width=gap_width)
+
+
+def build_document_master() -> Image.Image:
+    """The .krate document icon: a white page with a folded corner carrying
+    the crate glyph in Krate blue."""
+    image = Image.new("RGBA", (SIZE, SIZE), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(image)
+
+    page_left, page_top = 232, 96
+    page_right, page_bottom = 792, 928
+    fold = 150
+    page_color = (250, 250, 252, 255)
+    edge_color = (188, 195, 208, 255)
+    fold_color = (222, 227, 236, 255)
+
+    body = [
+        (page_left, page_top),
+        (page_right - fold, page_top),
+        (page_right, page_top + fold),
+        (page_right, page_bottom),
+        (page_left, page_bottom),
+    ]
+    draw.polygon(body, fill=page_color, outline=edge_color, width=6)
+    draw.polygon(
+        [
+            (page_right - fold, page_top),
+            (page_right, page_top + fold),
+            (page_right - fold, page_top + fold),
+        ],
+        fill=fold_color,
+        outline=edge_color,
+        width=6,
+    )
+
+    blue_face = (30, 140, 255, 255)
+    blue_left = (0, 110, 230, 255)
+    blue_right = (0, 88, 196, 255)
+    draw_crate_scaled(draw, cx=SIZE // 2, cy=580, scale=0.62,
+                      face=blue_face, left=blue_left, right=blue_right,
+                      gap_color=page_color)
+    return image
+
+
+def build_master() -> Image.Image:
+    background = gradient_background()
+
+    glyph = Image.new("RGBA", (SIZE, SIZE), (0, 0, 0, 0))
+    glyph_draw = ImageDraw.Draw(glyph)
+    draw_crate(glyph_draw)
+
+    tile = Image.new("RGBA", (SIZE, SIZE), (0, 0, 0, 0))
+    tile.paste(background, mask=rounded_tile_mask())
+    tile.alpha_composite(glyph)
+    return tile
+
+
+def main() -> int:
+    out_dir = Path(sys.argv[1] if len(sys.argv) > 1 else "dist/icon")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    for stem, master in (("Krate", build_master()), ("KrateDoc", build_document_master())):
+        master.save(out_dir / f"{stem.lower()}-1024.png")
+        iconset = out_dir / f"{stem}.iconset"
+        iconset.mkdir(parents=True, exist_ok=True)
+        for points in (16, 32, 128, 256, 512):
+            for scale in (1, 2):
+                pixels = points * scale
+                name = f"icon_{points}x{points}" + ("@2x" if scale == 2 else "") + ".png"
+                master.resize((pixels, pixels), Image.LANCZOS).save(iconset / name)
+        icns = out_dir / f"{stem}.icns"
+        subprocess.run(
+            ["/usr/bin/iconutil", "-c", "icns", str(iconset), "-o", str(icns)],
+            check=True,
+        )
+        print(f"wrote {icns}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/make-macos-app.sh
+++ b/scripts/make-macos-app.sh
@@ -25,7 +25,9 @@ for arg in "$@"; do
   esac
 done
 
-BINARY="target/$PROFILE/krate"
+# KRATE_BINARY overrides the binary location (release builds use
+# target/<triple>/release/krate); default is the local cargo profile dir.
+BINARY="${KRATE_BINARY:-target/$PROFILE/krate}"
 if [ ! -x "$BINARY" ]; then
   echo "missing $BINARY — build it first (cargo build -p krate-cli${PROFILE:+ --$PROFILE})" >&2
   exit 1
@@ -47,6 +49,18 @@ cat > "$APP/Contents/MacOS/Krate" << 'SHIM'
 exec "$(dirname "$0")/krate-cli" open-app
 SHIM
 chmod +x "$APP/Contents/MacOS/Krate"
+
+# App icon: regenerate from source when the tooling is present; ship without
+# an icon rather than fail when it is not (CI runners without PIL).
+if python3 -c "import PIL" 2>/dev/null; then
+  python3 scripts/make-app-icon.py "$OUT_DIR/icon" >/dev/null 2>&1 || true
+fi
+if [ -f "$OUT_DIR/icon/Krate.icns" ]; then
+  cp "$OUT_DIR/icon/Krate.icns" "$APP/Contents/Resources/Krate.icns"
+fi
+if [ -f "$OUT_DIR/icon/KrateDoc.icns" ]; then
+  cp "$OUT_DIR/icon/KrateDoc.icns" "$APP/Contents/Resources/KrateDoc.icns"
+fi
 
 VERSION="$("$BINARY" --version | awk '{print $2}')"
 
@@ -71,11 +85,15 @@ cat > "$APP/Contents/Info.plist" << PLIST
     <string>Krate</string>
     <key>NSHighResolutionCapable</key>
     <true/>
+    <key>CFBundleIconFile</key>
+    <string>Krate</string>
     <key>CFBundleDocumentTypes</key>
     <array>
         <dict>
             <key>CFBundleTypeName</key>
             <string>Krate App Bundle</string>
+            <key>CFBundleTypeIconFile</key>
+            <string>KrateDoc</string>
             <key>CFBundleTypeRole</key>
             <string>Viewer</string>
             <key>LSItemContentTypes</key>

--- a/scripts/make-macos-app.sh
+++ b/scripts/make-macos-app.sh
@@ -1,0 +1,121 @@
+#!/bin/sh
+# Assemble Krate.app, the macOS double-click entry point (P3-OPEN-03).
+#
+# The bundle declares the .krate document type, so Finder routes a
+# double-clicked .krate here. Launch Services starts the shim executable,
+# which execs `krate open-app`; that waits for the open-document Apple event,
+# then runs the bundle behind the native consent wall. Same binary, same
+# enforcement — only the entry gesture is new.
+#
+# Usage: scripts/make-macos-app.sh [output-dir] [--release]
+#   output-dir defaults to dist/. Pass --release to package the release build.
+set -eu
+
+case "$(uname -s)" in
+  Darwin) ;;
+  *) echo "Krate.app can only be assembled on macOS" >&2; exit 1 ;;
+esac
+
+OUT_DIR="dist"
+PROFILE="debug"
+for arg in "$@"; do
+  case "$arg" in
+    --release) PROFILE="release" ;;
+    *) OUT_DIR="$arg" ;;
+  esac
+done
+
+BINARY="target/$PROFILE/krate"
+if [ ! -x "$BINARY" ]; then
+  echo "missing $BINARY — build it first (cargo build -p krate-cli${PROFILE:+ --$PROFILE})" >&2
+  exit 1
+fi
+
+APP="$OUT_DIR/Krate.app"
+rm -rf "$APP"
+mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
+
+# Named krate-cli, not krate: the shim below is "Krate", and macOS filesystems
+# are case-insensitive by default, so "krate" and "Krate" would be one file.
+cp "$BINARY" "$APP/Contents/MacOS/krate-cli"
+
+# Launch Services invokes CFBundleExecutable with no arguments, so a shim
+# execs the real binary in open-app mode. exec keeps the PID, so the Apple
+# event still reaches the process Launch Services launched.
+cat > "$APP/Contents/MacOS/Krate" << 'SHIM'
+#!/bin/sh
+exec "$(dirname "$0")/krate-cli" open-app
+SHIM
+chmod +x "$APP/Contents/MacOS/Krate"
+
+VERSION="$("$BINARY" --version | awk '{print $2}')"
+
+cat > "$APP/Contents/Info.plist" << PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>Krate</string>
+    <key>CFBundleDisplayName</key>
+    <string>Krate</string>
+    <key>CFBundleIdentifier</key>
+    <string>dev.krate.app</string>
+    <key>CFBundleVersion</key>
+    <string>${VERSION}</string>
+    <key>CFBundleShortVersionString</key>
+    <string>${VERSION}</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleExecutable</key>
+    <string>Krate</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>CFBundleDocumentTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeName</key>
+            <string>Krate App Bundle</string>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>LSItemContentTypes</key>
+            <array>
+                <string>dev.krate.bundle</string>
+            </array>
+            <key>LSHandlerRank</key>
+            <string>Owner</string>
+        </dict>
+    </array>
+    <key>UTExportedTypeDeclarations</key>
+    <array>
+        <dict>
+            <key>UTTypeIdentifier</key>
+            <string>dev.krate.bundle</string>
+            <key>UTTypeDescription</key>
+            <string>Krate App Bundle</string>
+            <key>UTTypeConformsTo</key>
+            <array>
+                <string>public.data</string>
+            </array>
+            <key>UTTypeTagSpecification</key>
+            <dict>
+                <key>public.filename-extension</key>
+                <array>
+                    <string>krate</string>
+                </array>
+            </dict>
+        </dict>
+    </array>
+</dict>
+</plist>
+PLIST
+
+# Tell Launch Services about the bundle so Finder associates .krate with it.
+LSREGISTER="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+if [ -x "$LSREGISTER" ]; then
+  "$LSREGISTER" -f "$APP" >/dev/null 2>&1 || true
+fi
+
+echo "assembled $APP (profile: $PROFILE, version: $VERSION)"
+echo "test: open a .krate with it — e.g."
+echo "  open -a \"\$PWD/$APP\" path/to/app.krate"


### PR DESCRIPTION
P3-OPEN-01 (Change Order 4). Opening a bundle with `--consent` shows a native macOS window naming the app and listing each requested capability with the author's rationale and a per-capability checkbox. Open grants exactly what was left checked for the session; Cancel refuses and the component never runs. Refusing or unchecking a required capability produces the same structured denial (exit 5) as a withheld `--grant`.

macOS-only window for now, per the plan: Linux/Windows fall back to the terminal prompt through the same SessionPolicy fold. The Linux lane proves the semantics headlessly (allow-all runs and saves; refusal exits 5 with nothing written).

Verified interactively on macOS: the window renders app id + rationales, Open launches krate-notes with the granted set, Cancel and unchecked-required both refuse.