### PR TITLE
Full text-editing parity on the drawn path (Linux/Windows)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,6 +423,17 @@ jobs:
           rm -rf "$notes_dir" && mkdir -p "$notes_dir/notes"
           cp krate-fixture/krate_notes.wasm "$notes_dir/code.wasm"
           cp apps/krate-notes/manifest.toml "$notes_dir/manifest.toml"
+          # Requirement #10: the SAME bytecode runs on every OS. The notes wasm
+          # is built once in the hello-fixture job and downloaded here, so its
+          # hash must match across the Linux, macOS, and Windows lanes. Record
+          # it in the log on each lane; a mismatch means the shared artifact was
+          # not what ran.
+          if command -v sha256sum >/dev/null 2>&1; then
+            code_sha="$(sha256sum "$notes_dir/code.wasm" | awk '{print $1}')"
+          else
+            code_sha="$(shasum -a 256 "$notes_dir/code.wasm" | awk '{print $1}')"
+          fi
+          echo "notes code.wasm sha256 on $RUNNER_OS: $code_sha"
           target/debug/krate pack "$notes_dir/code.wasm" \
             --manifest "$notes_dir/manifest.toml" \
             -o "$notes_dir/notes.krate" || exit 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.59.0",
+ "x11rb",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +379,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
 
 [[package]]
 name = "cobs"
@@ -847,6 +873,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "euclid"
@@ -1568,6 +1600,7 @@ dependencies = [
 name = "krate-adapter-linux"
 version = "0.1.0-dev"
 dependencies = [
+ "arboard",
  "krate-adapter-common",
  "libc",
  "softbuffer",
@@ -1589,6 +1622,7 @@ dependencies = [
 name = "krate-adapter-windows"
 version = "0.1.0-dev"
 dependencies = [
+ "arboard",
  "krate-adapter-common",
  "softbuffer",
  "winit",
@@ -1772,6 +1806,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1949,6 +1992,7 @@ dependencies = [
  "bitflags 2.11.1",
  "objc2 0.6.4",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation 0.3.2",
 ]
 
@@ -2239,6 +2283,29 @@ checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -2768,6 +2835,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ rust-version = "1.91"
 
 [workspace.dependencies]
 anyhow = "1.0.102"
+# Cross-platform OS clipboard for the drawn path (Linux/Windows). macOS uses
+# the native NSTextField's own Cut/Copy/Paste, so it needs no clipboard crate.
+arboard = { version = "3.4", default-features = false }
 clap = { version = "4.6.1", features = ["derive"] }
 criterion = "0.8.2"
 libc = "0.2.177"

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,15 +1,16 @@
 # Krate Status (formerly Layer36)
 
-Last updated: 2026-07-23
+Last updated: 2026-07-25
 Naming: the project is Krate (company: Krate Labs, Inc.). The A9 rename is
 fully executed — CLI `krate`, WIT `krate:*`, schema `krate.run.v1`, env
 `KRATE_*`, repo `incyashraj/krate`, runner `krate-local`, future bundle
 format `.krate`. No legacy `layer36` identifiers remain in code or contracts.
 Repo: `incyashraj/krate`
 Branch: `main`
-Latest checked completed push before this status update: `8b1c9ec` (fast
-CI run `28740942296` green, then dispatched full matrix run `28741064867`
-green: all three OS lanes — certifying the vector-text renderer pass).
+Latest checked completed push before this status update: branch
+`slice/edit-parity` at `882c1cc`, full matrix run `30125544269` green on
+all three OS lanes — certifying full text-editing parity on the drawn path
+(the checkpoint below). Not yet merged to `main`.
 Direction change, 2026-07-23: shareability is now the wedge. Recorded in
 full as Change Order 2 in `Plan/Plan-Amendments-2026-07.md`, with the task
 spec as P3-SHARE-01 in `Plan/Phase-3-Plan.md` §19. Short version: Adam
@@ -23,7 +24,49 @@ Nothing architectural changes; portability stops being the headline and
 becomes how the property is achieved. The Adobe/Flash analogy is retired.
 Next implementation work is P3-SHARE-01, not further widget slices.
 
-Certification checkpoint 2026-07-23 (latest): a `.krate` opens like a
+Certification checkpoint 2026-07-25 (latest): the same `notes.krate`
+supports the full editing interaction on macOS, Linux, and Windows, not
+just macOS. Branch `slice/edit-parity`, commit `882c1cc`, full matrix run
+`30125544269` green on all three OS lanes. macOS already had
+Cut/Copy/Paste/Select All through the native NSTextField; the two missing
+pieces were Undo/Redo menu items (Cmd+Z / Cmd+Shift+Z now route through the
+field editor). The drawn path (Linux, Windows) paints its own text and has
+no native control, so the whole editor was built in the guest: `NoteBuffer`
+became a fixed-capacity, allocation-free, panic-free editor with a cursor, a
+selection anchor, and a 32-deep snapshot undo/redo stack — insert at caret
+(replacing any selection), backspace, forward delete, left/right/home/end
+movement (Shift extends), select-all, and delete-selection. A pure
+`classify_key()` maps key + modifiers to an action, so shortcut translation
+is one testable place: editing shortcuts fire on Control (Linux/Windows) or
+Meta (macOS), so the byte-identical guest honors each platform's native
+modifier. Cut/Copy/Paste round-trip through the real OS clipboard: the
+`krate:ui/clipboard` interface already existed end to end but the drawn
+adapters returned Unsupported; both now implement it via arboard (text-only,
+no image-data — clipboard-win's BSL-1.0 license was added to `deny.toml`).
+Clipboard is an optional capability — deny it and the app still opens,
+types, and saves; only Cut/Copy/Paste go quiet. A visible caret and
+selection required the one deliberate UAPI addition this change makes: a
+`krate:ui` `text-cursor` record on the widget node (a caret cannot ride an
+existing field), threaded through the placement and both painters (the
+bitmap painter uses its monospace cell grid, the vello painter measures
+prefix widths); a caret on a non-text widget is rejected at lowering. Tests:
+guest unit tests for shortcut translation, selection, editing, and
+undo/redo; painter tests for the caret and selection wash; runtime tests for
+the caret-lowering contract. The permission-denial behavior is unchanged —
+withholding `fs.write` still stops the app with exit 5 before any code runs,
+verified locally and on the Linux lane. Byte-identical bytecode everywhere
+is proven structurally: the notes `code.wasm` is built once in the
+fixtures job and downloaded by all three full-test lanes as the shared
+`phase-component-fixtures` artifact, so the same bytes run on every OS; the
+Linux notes proof logs its sha256 (`9cb8311a…`) for the record. Evidence
+note: the macOS editing (native control + Undo/Redo menu, Cmd shortcuts) is
+founder-verifiable interactively; the drawn-path editing, clipboard, and
+caret rendering are proven by the unit/painter/runtime tests plus the
+byte-identical `.krate` running headless on the Linux and Windows lanes. The
+rich drawn-path caret is not yet screenshot-verified in CI — that is the one
+thing a founder or a follow-up visual proof would still want to eyeball.
+
+Certification checkpoint 2026-07-23: a `.krate` opens like a
 document. Change Order 4's first arc is certified and merged (PR #9, merge
 `e61fa3f`, full matrix run `30001966785` green on all three OS lanes).
 P3-OPEN-01: opening a bundle with `--consent` shows a native macOS window

--- a/apps/krate-hello-gui/src/bindings.rs
+++ b/apps/krate-hello-gui/src/bindings.rs
@@ -5277,6 +5277,33 @@ pub mod krate {
                         .finish()
                 }
             }
+            /// A widget's complete text after a person edited it in a native control.
+            ///
+            /// Sent by hosts that lower widgets to real OS controls, where the control
+            /// holds the authoritative text. The app replaces its own copy with `text`
+            /// rather than appending, which is the only way deleting, selecting, and
+            /// pasting can be represented faithfully.
+            #[derive(Clone)]
+            pub struct TextChangedEvent {
+                /// Target window id.
+                pub window: u64,
+                /// Widget whose text changed.
+                pub widget: u64,
+                /// The control's complete text now.
+                pub text: _rt::String,
+            }
+            impl ::core::fmt::Debug for TextChangedEvent {
+                fn fmt(
+                    &self,
+                    f: &mut ::core::fmt::Formatter<'_>,
+                ) -> ::core::fmt::Result {
+                    f.debug_struct("TextChangedEvent")
+                        .field("window", &self.window)
+                        .field("widget", &self.widget)
+                        .field("text", &self.text)
+                        .finish()
+                }
+            }
             /// Keyboard input event delivered by the host.
             #[derive(Clone)]
             pub struct KeyEvent {
@@ -5467,6 +5494,33 @@ pub mod krate {
                     }
                 }
             }
+            /// Caret and selection inside a text widget, as byte offsets into its label.
+            ///
+            /// Hosts that paint their own text (Linux, Windows) have no native control to
+            /// hold a caret, so an app that implements editing itself reports where the
+            /// caret and selection sit and the painter draws them. `cursor` is the caret;
+            /// `anchor` is the other end of the selection. Equal offsets mean no
+            /// selection, just a caret. Hosts that lower to a real OS control ignore this:
+            /// the control owns its own caret.
+            #[repr(C)]
+            #[derive(Clone, Copy)]
+            pub struct TextCursor {
+                /// Caret position as a byte offset into the label, clamped to its length.
+                pub cursor: u32,
+                /// The other end of the selection. Equal to `cursor` means no selection.
+                pub anchor: u32,
+            }
+            impl ::core::fmt::Debug for TextCursor {
+                fn fmt(
+                    &self,
+                    f: &mut ::core::fmt::Formatter<'_>,
+                ) -> ::core::fmt::Result {
+                    f.debug_struct("TextCursor")
+                        .field("cursor", &self.cursor)
+                        .field("anchor", &self.anchor)
+                        .finish()
+                }
+            }
             /// Minimal style block for the first widget protocol draft.
             #[repr(C)]
             #[derive(Clone, Copy)]
@@ -5515,6 +5569,9 @@ pub mod krate {
                 /// Zero-based index of the selected child, for selectable container
                 /// kinds (list-view, tree-view). Out-of-range indices are rejected.
                 pub selected: Option<u32>,
+                /// Caret and selection for a text widget the app edits itself, drawn by
+                /// painting hosts. `none` leaves text caretless, as a passive label.
+                pub text_cursor: Option<TextCursor>,
             }
             impl ::core::fmt::Debug for WidgetNode {
                 fn fmt(
@@ -5531,6 +5588,7 @@ pub mod krate {
                         .field("checked", &self.checked)
                         .field("value", &self.value)
                         .field("selected", &self.selected)
+                        .field("text-cursor", &self.text_cursor)
                         .finish()
                 }
             }
@@ -5570,7 +5628,17 @@ pub mod krate {
                 /// Keyboard input changed.
                 Key(KeyEvent),
                 /// Text input after keyboard layout or IME processing.
+                ///
+                /// Append semantics: the characters named here were added to whatever the
+                /// app already had. Hosts that draw their own widgets send this.
                 TextInput(_rt::String),
+                /// A widget's complete text after the person edited it.
+                ///
+                /// Replace semantics: the app should set its buffer to exactly this.
+                /// Hosts that lower to real OS controls send this instead of `text-input`,
+                /// because the control owns the text and edits like deleting, selecting,
+                /// and pasting cannot be described as an append.
+                TextChanged(TextChangedEvent),
                 /// A widget or menu command fired.
                 Action(u64),
                 /// Focus moved to another widget.
@@ -5599,6 +5667,9 @@ pub mod krate {
                         Event::Key(e) => f.debug_tuple("Event::Key").field(e).finish(),
                         Event::TextInput(e) => {
                             f.debug_tuple("Event::TextInput").field(e).finish()
+                        }
+                        Event::TextChanged(e) => {
+                            f.debug_tuple("Event::TextChanged").field(e).finish()
                         }
                         Event::Action(e) => {
                             f.debug_tuple("Event::Action").field(e).finish()
@@ -6320,11 +6391,11 @@ pub mod krate {
                     struct RetArea(
                         [::core::mem::MaybeUninit<
                             u8,
-                        >; 72 + 8 * ::core::mem::size_of::<*const u8>()],
+                        >; 96 + 6 * ::core::mem::size_of::<*const u8>()],
                     );
                     let mut ret_area = RetArea(
-                        [::core::mem::MaybeUninit::uninit(); 72
-                            + 8 * ::core::mem::size_of::<*const u8>()],
+                        [::core::mem::MaybeUninit::uninit(); 96
+                            + 6 * ::core::mem::size_of::<*const u8>()],
                     );
                     let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                     *ptr0.add(0).cast::<i64>() = _rt::as_i64(&window);
@@ -6338,6 +6409,7 @@ pub mod krate {
                         checked: checked1,
                         value: value1,
                         selected: selected1,
+                        text_cursor: text_cursor1,
                     } = root;
                     *ptr0.add(8).cast::<i64>() = _rt::as_i64(id1);
                     match parent1 {
@@ -6482,79 +6554,101 @@ pub mod krate {
                                 .cast::<u8>() = (0i32) as u8;
                         }
                     };
-                    let ptr5 = ret_area.0.as_mut_ptr().cast::<u8>();
+                    match text_cursor1 {
+                        Some(e) => {
+                            *ptr0
+                                .add(76 + 7 * ::core::mem::size_of::<*const u8>())
+                                .cast::<u8>() = (1i32) as u8;
+                            let super::super::super::krate::ui::types::TextCursor {
+                                cursor: cursor5,
+                                anchor: anchor5,
+                            } = e;
+                            *ptr0
+                                .add(80 + 7 * ::core::mem::size_of::<*const u8>())
+                                .cast::<i32>() = _rt::as_i32(cursor5);
+                            *ptr0
+                                .add(84 + 7 * ::core::mem::size_of::<*const u8>())
+                                .cast::<i32>() = _rt::as_i32(anchor5);
+                        }
+                        None => {
+                            *ptr0
+                                .add(76 + 7 * ::core::mem::size_of::<*const u8>())
+                                .cast::<u8>() = (0i32) as u8;
+                        }
+                    };
+                    let ptr6 = ret_area.0.as_mut_ptr().cast::<u8>();
                     #[cfg(target_arch = "wasm32")]
                     #[link(wasm_import_module = "krate:ui/tree@0.1.0")]
                     unsafe extern "C" {
                         #[link_name = "set-root"]
-                        fn wit_import6(_: *mut u8, _: *mut u8);
+                        fn wit_import7(_: *mut u8, _: *mut u8);
                     }
                     #[cfg(not(target_arch = "wasm32"))]
-                    unsafe extern "C" fn wit_import6(_: *mut u8, _: *mut u8) {
+                    unsafe extern "C" fn wit_import7(_: *mut u8, _: *mut u8) {
                         unreachable!()
                     }
-                    unsafe { wit_import6(ptr0, ptr5) };
-                    let l7 = i32::from(*ptr5.add(0).cast::<u8>());
-                    let result16 = match l7 {
+                    unsafe { wit_import7(ptr0, ptr6) };
+                    let l8 = i32::from(*ptr6.add(0).cast::<u8>());
+                    let result17 = match l8 {
                         0 => {
                             let e = ();
                             Ok(e)
                         }
                         1 => {
                             let e = {
-                                let l8 = i32::from(
-                                    *ptr5.add(::core::mem::size_of::<*const u8>()).cast::<u8>(),
+                                let l9 = i32::from(
+                                    *ptr6.add(::core::mem::size_of::<*const u8>()).cast::<u8>(),
                                 );
-                                use super::super::super::krate::ui::types::UiError as V15;
-                                let v15 = match l8 {
-                                    0 => V15::PermissionDenied,
-                                    1 => V15::InvalidWindow,
-                                    2 => V15::InvalidWidget,
+                                use super::super::super::krate::ui::types::UiError as V16;
+                                let v16 = match l9 {
+                                    0 => V16::PermissionDenied,
+                                    1 => V16::InvalidWindow,
+                                    2 => V16::InvalidWidget,
                                     3 => {
-                                        let e15 = {
-                                            let l9 = *ptr5
+                                        let e16 = {
+                                            let l10 = *ptr6
                                                 .add(2 * ::core::mem::size_of::<*const u8>())
                                                 .cast::<*mut u8>();
-                                            let l10 = *ptr5
+                                            let l11 = *ptr6
                                                 .add(3 * ::core::mem::size_of::<*const u8>())
                                                 .cast::<usize>();
-                                            let len11 = l10;
-                                            let bytes11 = _rt::Vec::from_raw_parts(
-                                                l9.cast(),
-                                                len11,
-                                                len11,
+                                            let len12 = l11;
+                                            let bytes12 = _rt::Vec::from_raw_parts(
+                                                l10.cast(),
+                                                len12,
+                                                len12,
                                             );
-                                            _rt::string_lift(bytes11)
+                                            _rt::string_lift(bytes12)
                                         };
-                                        V15::Unsupported(e15)
+                                        V16::Unsupported(e16)
                                     }
                                     n => {
                                         debug_assert_eq!(n, 4, "invalid enum discriminant");
-                                        let e15 = {
-                                            let l12 = *ptr5
+                                        let e16 = {
+                                            let l13 = *ptr6
                                                 .add(2 * ::core::mem::size_of::<*const u8>())
                                                 .cast::<*mut u8>();
-                                            let l13 = *ptr5
+                                            let l14 = *ptr6
                                                 .add(3 * ::core::mem::size_of::<*const u8>())
                                                 .cast::<usize>();
-                                            let len14 = l13;
-                                            let bytes14 = _rt::Vec::from_raw_parts(
-                                                l12.cast(),
-                                                len14,
-                                                len14,
+                                            let len15 = l14;
+                                            let bytes15 = _rt::Vec::from_raw_parts(
+                                                l13.cast(),
+                                                len15,
+                                                len15,
                                             );
-                                            _rt::string_lift(bytes14)
+                                            _rt::string_lift(bytes15)
                                         };
-                                        V15::Platform(e15)
+                                        V16::Platform(e16)
                                     }
                                 };
-                                v15
+                                v16
                             };
                             Err(e)
                         }
                         _ => _rt::invalid_enum_discriminant(),
                     };
-                    result16
+                    result17
                 }
             }
             #[allow(unused_unsafe, clippy::all)]
@@ -6565,11 +6659,11 @@ pub mod krate {
                     struct RetArea(
                         [::core::mem::MaybeUninit<
                             u8,
-                        >; 72 + 8 * ::core::mem::size_of::<*const u8>()],
+                        >; 96 + 6 * ::core::mem::size_of::<*const u8>()],
                     );
                     let mut ret_area = RetArea(
-                        [::core::mem::MaybeUninit::uninit(); 72
-                            + 8 * ::core::mem::size_of::<*const u8>()],
+                        [::core::mem::MaybeUninit::uninit(); 96
+                            + 6 * ::core::mem::size_of::<*const u8>()],
                     );
                     let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                     *ptr0.add(0).cast::<i64>() = _rt::as_i64(&window);
@@ -6583,6 +6677,7 @@ pub mod krate {
                         checked: checked1,
                         value: value1,
                         selected: selected1,
+                        text_cursor: text_cursor1,
                     } = node;
                     *ptr0.add(8).cast::<i64>() = _rt::as_i64(id1);
                     match parent1 {
@@ -6727,79 +6822,101 @@ pub mod krate {
                                 .cast::<u8>() = (0i32) as u8;
                         }
                     };
-                    let ptr5 = ret_area.0.as_mut_ptr().cast::<u8>();
+                    match text_cursor1 {
+                        Some(e) => {
+                            *ptr0
+                                .add(76 + 7 * ::core::mem::size_of::<*const u8>())
+                                .cast::<u8>() = (1i32) as u8;
+                            let super::super::super::krate::ui::types::TextCursor {
+                                cursor: cursor5,
+                                anchor: anchor5,
+                            } = e;
+                            *ptr0
+                                .add(80 + 7 * ::core::mem::size_of::<*const u8>())
+                                .cast::<i32>() = _rt::as_i32(cursor5);
+                            *ptr0
+                                .add(84 + 7 * ::core::mem::size_of::<*const u8>())
+                                .cast::<i32>() = _rt::as_i32(anchor5);
+                        }
+                        None => {
+                            *ptr0
+                                .add(76 + 7 * ::core::mem::size_of::<*const u8>())
+                                .cast::<u8>() = (0i32) as u8;
+                        }
+                    };
+                    let ptr6 = ret_area.0.as_mut_ptr().cast::<u8>();
                     #[cfg(target_arch = "wasm32")]
                     #[link(wasm_import_module = "krate:ui/tree@0.1.0")]
                     unsafe extern "C" {
                         #[link_name = "upsert-node"]
-                        fn wit_import6(_: *mut u8, _: *mut u8);
+                        fn wit_import7(_: *mut u8, _: *mut u8);
                     }
                     #[cfg(not(target_arch = "wasm32"))]
-                    unsafe extern "C" fn wit_import6(_: *mut u8, _: *mut u8) {
+                    unsafe extern "C" fn wit_import7(_: *mut u8, _: *mut u8) {
                         unreachable!()
                     }
-                    unsafe { wit_import6(ptr0, ptr5) };
-                    let l7 = i32::from(*ptr5.add(0).cast::<u8>());
-                    let result16 = match l7 {
+                    unsafe { wit_import7(ptr0, ptr6) };
+                    let l8 = i32::from(*ptr6.add(0).cast::<u8>());
+                    let result17 = match l8 {
                         0 => {
                             let e = ();
                             Ok(e)
                         }
                         1 => {
                             let e = {
-                                let l8 = i32::from(
-                                    *ptr5.add(::core::mem::size_of::<*const u8>()).cast::<u8>(),
+                                let l9 = i32::from(
+                                    *ptr6.add(::core::mem::size_of::<*const u8>()).cast::<u8>(),
                                 );
-                                use super::super::super::krate::ui::types::UiError as V15;
-                                let v15 = match l8 {
-                                    0 => V15::PermissionDenied,
-                                    1 => V15::InvalidWindow,
-                                    2 => V15::InvalidWidget,
+                                use super::super::super::krate::ui::types::UiError as V16;
+                                let v16 = match l9 {
+                                    0 => V16::PermissionDenied,
+                                    1 => V16::InvalidWindow,
+                                    2 => V16::InvalidWidget,
                                     3 => {
-                                        let e15 = {
-                                            let l9 = *ptr5
+                                        let e16 = {
+                                            let l10 = *ptr6
                                                 .add(2 * ::core::mem::size_of::<*const u8>())
                                                 .cast::<*mut u8>();
-                                            let l10 = *ptr5
+                                            let l11 = *ptr6
                                                 .add(3 * ::core::mem::size_of::<*const u8>())
                                                 .cast::<usize>();
-                                            let len11 = l10;
-                                            let bytes11 = _rt::Vec::from_raw_parts(
-                                                l9.cast(),
-                                                len11,
-                                                len11,
+                                            let len12 = l11;
+                                            let bytes12 = _rt::Vec::from_raw_parts(
+                                                l10.cast(),
+                                                len12,
+                                                len12,
                                             );
-                                            _rt::string_lift(bytes11)
+                                            _rt::string_lift(bytes12)
                                         };
-                                        V15::Unsupported(e15)
+                                        V16::Unsupported(e16)
                                     }
                                     n => {
                                         debug_assert_eq!(n, 4, "invalid enum discriminant");
-                                        let e15 = {
-                                            let l12 = *ptr5
+                                        let e16 = {
+                                            let l13 = *ptr6
                                                 .add(2 * ::core::mem::size_of::<*const u8>())
                                                 .cast::<*mut u8>();
-                                            let l13 = *ptr5
+                                            let l14 = *ptr6
                                                 .add(3 * ::core::mem::size_of::<*const u8>())
                                                 .cast::<usize>();
-                                            let len14 = l13;
-                                            let bytes14 = _rt::Vec::from_raw_parts(
-                                                l12.cast(),
-                                                len14,
-                                                len14,
+                                            let len15 = l14;
+                                            let bytes15 = _rt::Vec::from_raw_parts(
+                                                l13.cast(),
+                                                len15,
+                                                len15,
                                             );
-                                            _rt::string_lift(bytes14)
+                                            _rt::string_lift(bytes15)
                                         };
-                                        V15::Platform(e15)
+                                        V16::Platform(e16)
                                     }
                                 };
-                                v15
+                                v16
                             };
                             Err(e)
                         }
                         _ => _rt::invalid_enum_discriminant(),
                     };
-                    result16
+                    result17
                 }
             }
             #[allow(unused_unsafe, clippy::all)]
@@ -7137,22 +7254,22 @@ pub mod krate {
                     }
                     unsafe { wit_import1(ptr0) };
                     let l2 = i32::from(*ptr0.add(0).cast::<u8>());
-                    let result39 = match l2 {
+                    let result44 = match l2 {
                         0 => None,
                         1 => {
                             let e = {
                                 let l3 = i32::from(*ptr0.add(8).cast::<u8>());
-                                use super::super::super::krate::ui::types::Event as V38;
-                                let v38 = match l3 {
+                                use super::super::super::krate::ui::types::Event as V43;
+                                let v43 = match l3 {
                                     0 => {
-                                        let e38 = {
+                                        let e43 = {
                                             let l4 = *ptr0.add(16).cast::<i64>();
                                             l4 as u64
                                         };
-                                        V38::CloseRequested(e38)
+                                        V43::CloseRequested(e43)
                                     }
                                     1 => {
-                                        let e38 = {
+                                        let e43 = {
                                             let l5 = *ptr0.add(16).cast::<i32>();
                                             let l6 = *ptr0.add(20).cast::<i32>();
                                             super::super::super::krate::ui::types::WindowSize {
@@ -7160,17 +7277,17 @@ pub mod krate {
                                                 height: l6 as u32,
                                             }
                                         };
-                                        V38::Resized(e38)
+                                        V43::Resized(e43)
                                     }
                                     2 => {
-                                        let e38 = {
+                                        let e43 = {
                                             let l7 = *ptr0.add(16).cast::<i64>();
                                             l7 as u64
                                         };
-                                        V38::RedrawRequested(e38)
+                                        V43::RedrawRequested(e43)
                                     }
                                     3 => {
-                                        let e38 = {
+                                        let e43 = {
                                             let l8 = *ptr0.add(16).cast::<i64>();
                                             let l9 = i32::from(*ptr0.add(24).cast::<u8>());
                                             let l11 = *ptr0.add(40).cast::<f32>();
@@ -7218,10 +7335,10 @@ pub mod krate {
                                                 },
                                             }
                                         };
-                                        V38::Pointer(e38)
+                                        V43::Pointer(e43)
                                     }
                                     4 => {
-                                        let e38 = {
+                                        let e43 = {
                                             let l20 = *ptr0.add(16).cast::<i64>();
                                             let l21 = i32::from(*ptr0.add(24).cast::<u8>());
                                             let l23 = *ptr0.add(40).cast::<*mut u8>();
@@ -7282,10 +7399,10 @@ pub mod krate {
                                                 },
                                             }
                                         };
-                                        V38::Key(e38)
+                                        V43::Key(e43)
                                     }
                                     5 => {
-                                        let e38 = {
+                                        let e43 = {
                                             let l31 = *ptr0.add(16).cast::<*mut u8>();
                                             let l32 = *ptr0
                                                 .add(16 + 1 * ::core::mem::size_of::<*const u8>())
@@ -7298,50 +7415,72 @@ pub mod krate {
                                             );
                                             _rt::string_lift(bytes33)
                                         };
-                                        V38::TextInput(e38)
+                                        V43::TextInput(e43)
                                     }
                                     6 => {
-                                        let e38 = {
+                                        let e43 = {
                                             let l34 = *ptr0.add(16).cast::<i64>();
-                                            l34 as u64
+                                            let l35 = *ptr0.add(24).cast::<i64>();
+                                            let l36 = *ptr0.add(32).cast::<*mut u8>();
+                                            let l37 = *ptr0
+                                                .add(32 + 1 * ::core::mem::size_of::<*const u8>())
+                                                .cast::<usize>();
+                                            let len38 = l37;
+                                            let bytes38 = _rt::Vec::from_raw_parts(
+                                                l36.cast(),
+                                                len38,
+                                                len38,
+                                            );
+                                            super::super::super::krate::ui::types::TextChangedEvent {
+                                                window: l34 as u64,
+                                                widget: l35 as u64,
+                                                text: _rt::string_lift(bytes38),
+                                            }
                                         };
-                                        V38::Action(e38)
+                                        V43::TextChanged(e43)
                                     }
                                     7 => {
-                                        let e38 = {
-                                            let l35 = i32::from(*ptr0.add(16).cast::<u8>());
-                                            match l35 {
+                                        let e43 = {
+                                            let l39 = *ptr0.add(16).cast::<i64>();
+                                            l39 as u64
+                                        };
+                                        V43::Action(e43)
+                                    }
+                                    8 => {
+                                        let e43 = {
+                                            let l40 = i32::from(*ptr0.add(16).cast::<u8>());
+                                            match l40 {
                                                 0 => None,
                                                 1 => {
                                                     let e = {
-                                                        let l36 = *ptr0.add(24).cast::<i64>();
-                                                        l36 as u64
+                                                        let l41 = *ptr0.add(24).cast::<i64>();
+                                                        l41 as u64
                                                     };
                                                     Some(e)
                                                 }
                                                 _ => _rt::invalid_enum_discriminant(),
                                             }
                                         };
-                                        V38::FocusChanged(e38)
+                                        V43::FocusChanged(e43)
                                     }
                                     n => {
-                                        debug_assert_eq!(n, 8, "invalid enum discriminant");
-                                        let e38 = {
-                                            let l37 = i32::from(*ptr0.add(16).cast::<u8>());
+                                        debug_assert_eq!(n, 9, "invalid enum discriminant");
+                                        let e43 = {
+                                            let l42 = i32::from(*ptr0.add(16).cast::<u8>());
                                             super::super::super::krate::ui::types::Theme::_lift(
-                                                l37 as u8,
+                                                l42 as u8,
                                             )
                                         };
-                                        V38::ThemeChanged(e38)
+                                        V43::ThemeChanged(e43)
                                     }
                                 };
-                                v38
+                                v43
                             };
                             Some(e)
                         }
                         _ => _rt::invalid_enum_discriminant(),
                     };
-                    result39
+                    result44
                 }
             }
             #[allow(unused_unsafe, clippy::all)]
@@ -7375,22 +7514,22 @@ pub mod krate {
                     }
                     unsafe { wit_import2(result0_0, result0_1, ptr1) };
                     let l3 = i32::from(*ptr1.add(0).cast::<u8>());
-                    let result40 = match l3 {
+                    let result45 = match l3 {
                         0 => None,
                         1 => {
                             let e = {
                                 let l4 = i32::from(*ptr1.add(8).cast::<u8>());
-                                use super::super::super::krate::ui::types::Event as V39;
-                                let v39 = match l4 {
+                                use super::super::super::krate::ui::types::Event as V44;
+                                let v44 = match l4 {
                                     0 => {
-                                        let e39 = {
+                                        let e44 = {
                                             let l5 = *ptr1.add(16).cast::<i64>();
                                             l5 as u64
                                         };
-                                        V39::CloseRequested(e39)
+                                        V44::CloseRequested(e44)
                                     }
                                     1 => {
-                                        let e39 = {
+                                        let e44 = {
                                             let l6 = *ptr1.add(16).cast::<i32>();
                                             let l7 = *ptr1.add(20).cast::<i32>();
                                             super::super::super::krate::ui::types::WindowSize {
@@ -7398,17 +7537,17 @@ pub mod krate {
                                                 height: l7 as u32,
                                             }
                                         };
-                                        V39::Resized(e39)
+                                        V44::Resized(e44)
                                     }
                                     2 => {
-                                        let e39 = {
+                                        let e44 = {
                                             let l8 = *ptr1.add(16).cast::<i64>();
                                             l8 as u64
                                         };
-                                        V39::RedrawRequested(e39)
+                                        V44::RedrawRequested(e44)
                                     }
                                     3 => {
-                                        let e39 = {
+                                        let e44 = {
                                             let l9 = *ptr1.add(16).cast::<i64>();
                                             let l10 = i32::from(*ptr1.add(24).cast::<u8>());
                                             let l12 = *ptr1.add(40).cast::<f32>();
@@ -7456,10 +7595,10 @@ pub mod krate {
                                                 },
                                             }
                                         };
-                                        V39::Pointer(e39)
+                                        V44::Pointer(e44)
                                     }
                                     4 => {
-                                        let e39 = {
+                                        let e44 = {
                                             let l21 = *ptr1.add(16).cast::<i64>();
                                             let l22 = i32::from(*ptr1.add(24).cast::<u8>());
                                             let l24 = *ptr1.add(40).cast::<*mut u8>();
@@ -7520,10 +7659,10 @@ pub mod krate {
                                                 },
                                             }
                                         };
-                                        V39::Key(e39)
+                                        V44::Key(e44)
                                     }
                                     5 => {
-                                        let e39 = {
+                                        let e44 = {
                                             let l32 = *ptr1.add(16).cast::<*mut u8>();
                                             let l33 = *ptr1
                                                 .add(16 + 1 * ::core::mem::size_of::<*const u8>())
@@ -7536,50 +7675,72 @@ pub mod krate {
                                             );
                                             _rt::string_lift(bytes34)
                                         };
-                                        V39::TextInput(e39)
+                                        V44::TextInput(e44)
                                     }
                                     6 => {
-                                        let e39 = {
+                                        let e44 = {
                                             let l35 = *ptr1.add(16).cast::<i64>();
-                                            l35 as u64
+                                            let l36 = *ptr1.add(24).cast::<i64>();
+                                            let l37 = *ptr1.add(32).cast::<*mut u8>();
+                                            let l38 = *ptr1
+                                                .add(32 + 1 * ::core::mem::size_of::<*const u8>())
+                                                .cast::<usize>();
+                                            let len39 = l38;
+                                            let bytes39 = _rt::Vec::from_raw_parts(
+                                                l37.cast(),
+                                                len39,
+                                                len39,
+                                            );
+                                            super::super::super::krate::ui::types::TextChangedEvent {
+                                                window: l35 as u64,
+                                                widget: l36 as u64,
+                                                text: _rt::string_lift(bytes39),
+                                            }
                                         };
-                                        V39::Action(e39)
+                                        V44::TextChanged(e44)
                                     }
                                     7 => {
-                                        let e39 = {
-                                            let l36 = i32::from(*ptr1.add(16).cast::<u8>());
-                                            match l36 {
+                                        let e44 = {
+                                            let l40 = *ptr1.add(16).cast::<i64>();
+                                            l40 as u64
+                                        };
+                                        V44::Action(e44)
+                                    }
+                                    8 => {
+                                        let e44 = {
+                                            let l41 = i32::from(*ptr1.add(16).cast::<u8>());
+                                            match l41 {
                                                 0 => None,
                                                 1 => {
                                                     let e = {
-                                                        let l37 = *ptr1.add(24).cast::<i64>();
-                                                        l37 as u64
+                                                        let l42 = *ptr1.add(24).cast::<i64>();
+                                                        l42 as u64
                                                     };
                                                     Some(e)
                                                 }
                                                 _ => _rt::invalid_enum_discriminant(),
                                             }
                                         };
-                                        V39::FocusChanged(e39)
+                                        V44::FocusChanged(e44)
                                     }
                                     n => {
-                                        debug_assert_eq!(n, 8, "invalid enum discriminant");
-                                        let e39 = {
-                                            let l38 = i32::from(*ptr1.add(16).cast::<u8>());
+                                        debug_assert_eq!(n, 9, "invalid enum discriminant");
+                                        let e44 = {
+                                            let l43 = i32::from(*ptr1.add(16).cast::<u8>());
                                             super::super::super::krate::ui::types::Theme::_lift(
-                                                l38 as u8,
+                                                l43 as u8,
                                             )
                                         };
-                                        V39::ThemeChanged(e39)
+                                        V44::ThemeChanged(e44)
                                     }
                                 };
-                                v39
+                                v44
                             };
                             Some(e)
                         }
                         _ => _rt::invalid_enum_discriminant(),
                     };
-                    result40
+                    result45
                 }
             }
         }
@@ -8464,8 +8625,8 @@ pub(crate) use __export_gui_impl as export;
 )]
 #[doc(hidden)]
 #[allow(clippy::octal_escapes)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 6533] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\x8b2\x01A\x02\x01AQ\x01\
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 6650] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\x803\x01A\x02\x01AQ\x01\
 B\x04\x01m\x05\x05trace\x05debug\x04info\x04warn\x05error\x04\0\x09log-level\x03\
 \0\0\x01q\x05\x06closed\0\0\x0binterrupted\0\0\x0eunexpected-eof\0\0\x0cinvalid-\
 utf8\0\0\x05other\x01s\0\x04\0\x08io-error\x03\0\x02\x03\0\x14krate:io/types@0.1\
@@ -8530,92 +8691,94 @@ ale/info@0.1.0\x05\x17\x02\x03\0\x0b\x0adate-style\x02\x03\0\x0b\x0cnumber-style
 \0\x0adate-style\x03\0\x02\x02\x03\x02\x01\x19\x04\0\x0cnumber-style\x03\0\x04\x01\
 @\x04\x06millisw\x02tzs\x05style\x03\x03loc\x01\0s\x04\0\x0bformat-date\x01\x06\x01\
 @\x03\x05valueu\x05style\x05\x03loc\x01\0s\x04\0\x0dformat-number\x01\x07\x03\0\x19\
-krate:locale/format@0.1.0\x05\x1a\x01B\"\x01m\x04\x06normal\x09minimized\x09maxi\
-mized\x0afullscreen\x04\0\x0cwindow-state\x03\0\0\x01r\x02\x05widthy\x06heighty\x04\
+krate:locale/format@0.1.0\x05\x1a\x01B'\x01m\x04\x06normal\x09minimized\x09maxim\
+ized\x0afullscreen\x04\0\x0cwindow-state\x03\0\0\x01r\x02\x05widthy\x06heighty\x04\
 \0\x0bwindow-size\x03\0\x02\x01r\x04\x01xv\x01yv\x05widthv\x06heightv\x04\0\x04r\
 ect\x03\0\x04\x01m\x03\x05light\x04dark\x07unknown\x04\0\x05theme\x03\0\x06\x01m\
 \x04\x07primary\x09secondary\x06middle\x05other\x04\0\x0epointer-button\x03\0\x08\
 \x01r\x04\x05shift\x7f\x07control\x7f\x03alt\x7f\x04meta\x7f\x04\0\x09modifiers\x03\
 \0\x0a\x01kw\x01k\x09\x01r\x07\x06windoww\x06widget\x0c\x01xv\x01yv\x06button\x0d\
-\x07pressed\x7f\x09modifiers\x0b\x04\0\x0dpointer-event\x03\0\x0e\x01r\x05\x06wi\
-ndoww\x06widget\x0c\x03keys\x07pressed\x7f\x09modifiers\x0b\x04\0\x09key-event\x03\
-\0\x10\x01q\x05\x11permission-denied\0\0\x0einvalid-window\0\0\x0einvalid-widget\
-\0\0\x0bunsupported\x01s\0\x08platform\x01s\0\x04\0\x08ui-error\x03\0\x12\x01m\x11\
+\x07pressed\x7f\x09modifiers\x0b\x04\0\x0dpointer-event\x03\0\x0e\x01r\x03\x06wi\
+ndoww\x06widgetw\x04texts\x04\0\x12text-changed-event\x03\0\x10\x01r\x05\x06wind\
+oww\x06widget\x0c\x03keys\x07pressed\x7f\x09modifiers\x0b\x04\0\x09key-event\x03\
+\0\x12\x01q\x05\x11permission-denied\0\0\x0einvalid-window\0\0\x0einvalid-widget\
+\0\0\x0bunsupported\x01s\0\x08platform\x01s\0\x04\0\x08ui-error\x03\0\x14\x01m\x11\
 \x05stack\x04grid\x06scroll\x04tabs\x06button\x08checkbox\x05radio\x06switch\x06\
 slider\x08progress\x04text\x0atext-field\x09text-area\x09list-view\x09tree-view\x05\
-image\x06canvas\x04\0\x0bwidget-kind\x03\0\x14\x01kv\x01r\x04\x05width\x16\x06he\
-ight\x16\x04growv\x07paddingv\x04\0\x05style\x03\0\x17\x01ks\x01k\x7f\x01ky\x01r\
-\x09\x02idw\x06parent\x0c\x04kind\x15\x05label\x19\x04role\x19\x05style\x18\x07c\
-hecked\x1a\x05value\x16\x08selected\x1b\x04\0\x0bwidget-node\x03\0\x1c\x01r\x03\x02\
-idw\x05labels\x07enabled\x7f\x04\0\x09menu-item\x03\0\x1e\x01q\x09\x0fclose-requ\
-ested\x01w\0\x07resized\x01\x03\0\x10redraw-requested\x01w\0\x07pointer\x01\x0f\0\
-\x03key\x01\x11\0\x0atext-input\x01s\0\x06action\x01w\0\x0dfocus-changed\x01\x0c\
-\0\x0dtheme-changed\x01\x07\0\x04\0\x05event\x03\0\x20\x03\0\x14krate:ui/types@0\
-.1.0\x05\x1b\x02\x03\0\x0e\x08ui-error\x02\x03\0\x0e\x0bwindow-size\x02\x03\0\x0e\
-\x0cwindow-state\x01B\x14\x02\x03\x02\x01\x1c\x04\0\x08ui-error\x03\0\0\x02\x03\x02\
-\x01\x1d\x04\0\x0bwindow-size\x03\0\x02\x02\x03\x02\x01\x1e\x04\0\x0cwindow-stat\
-e\x03\0\x04\x01j\x01w\x01\x01\x01@\x02\x05titles\x04size\x03\0\x06\x04\0\x06crea\
-te\x01\x07\x01j\0\x01\x01\x01@\x01\x06windoww\0\x08\x04\0\x04show\x01\x09\x04\0\x05\
-close\x01\x09\x01@\x02\x06windoww\x05titles\0\x08\x04\0\x09set-title\x01\x0a\x01\
-@\x02\x06windoww\x04size\x03\0\x08\x04\0\x08set-size\x01\x0b\x01@\x02\x06windoww\
-\x05state\x05\0\x08\x04\0\x09set-state\x01\x0c\x04\0\x0erequest-redraw\x01\x09\x03\
-\0\x15krate:ui/window@0.1.0\x05\x1f\x02\x03\0\x0e\x0bwidget-node\x01B\x0e\x02\x03\
-\x02\x01\x1c\x04\0\x08ui-error\x03\0\0\x02\x03\x02\x01\x20\x04\0\x0bwidget-node\x03\
-\0\x02\x01j\0\x01\x01\x01@\x02\x06windoww\x04root\x03\0\x04\x04\0\x08set-root\x01\
-\x05\x01@\x02\x06windoww\x04node\x03\0\x04\x04\0\x0bupsert-node\x01\x06\x01@\x02\
-\x06windoww\x06widgetw\0\x04\x04\0\x0bremove-node\x01\x07\x04\0\x0afocus-node\x01\
-\x07\x01@\x03\x06windoww\x06widgetw\x07enabled\x7f\0\x04\x04\0\x0bset-enabled\x01\
-\x08\x03\0\x13krate:ui/tree@0.1.0\x05!\x02\x03\0\x0e\x05event\x01B\x08\x02\x03\x02\
-\x01\"\x04\0\x05event\x03\0\0\x01k\x01\x01@\0\0\x02\x04\0\x04poll\x01\x03\x01ky\x01\
-@\x01\x0etimeout-millis\x04\0\x02\x04\0\x04wait\x01\x05\x03\0\x15krate:ui/events\
-@0.1.0\x05#\x01B\x08\x02\x03\x02\x01\x1c\x04\0\x08ui-error\x03\0\0\x01j\0\x01\x01\
-\x01@\x03\x06windoww\x05titles\x04bodys\0\x02\x04\0\x07message\x01\x03\x01j\x01\x7f\
-\x01\x01\x01@\x03\x06windoww\x05titles\x04bodys\0\x04\x04\0\x07confirm\x01\x05\x03\
-\0\x15krate:ui/dialog@0.1.0\x05$\x01B\x08\x02\x03\x02\x01\x1c\x04\0\x08ui-error\x03\
-\0\0\x01j\x01s\x01\x01\x01@\0\0\x02\x04\0\x09read-text\x01\x03\x01j\0\x01\x01\x01\
-@\x01\x04texts\0\x04\x04\0\x0awrite-text\x01\x05\x03\0\x18krate:ui/clipboard@0.1\
-.0\x05%\x02\x03\0\x0e\x09menu-item\x01B\x08\x02\x03\x02\x01&\x04\0\x09menu-item\x03\
-\0\0\x02\x03\x02\x01\x1c\x04\0\x08ui-error\x03\0\x02\x01p\x01\x01j\0\x01\x03\x01\
-@\x02\x06windoww\x05items\x04\0\x05\x04\0\x09set-items\x01\x06\x03\0\x13krate:ui\
-/menu@0.1.0\x05'\x01B\x14\x01r\x04\x01rv\x01gv\x01bv\x01av\x04\0\x05color\x03\0\0\
-\x01r\x02\x01xv\x01yv\x04\0\x05point\x03\0\x02\x01r\x02\x05widthv\x06heightv\x04\
-\0\x04size\x03\0\x04\x01r\x04\x01xv\x01yv\x05widthv\x06heightv\x04\0\x04rect\x03\
-\0\x06\x01r\x05\x04texts\x06origin\x03\x0bfont-familys\x09font-sizev\x05color\x01\
-\x04\0\x08text-run\x03\0\x08\x01q\x04\x11permission-denied\0\0\x0einvalid-target\
-\0\0\x0bunsupported\x01s\0\x08platform\x01s\0\x04\0\x09gfx-error\x03\0\x0a\x01r\x02\
-\x04rect\x07\x05color\x01\x04\0\x11fill-rect-command\x03\0\x0c\x01r\x03\x04rect\x07\
-\x05color\x01\x05widthv\x04\0\x13stroke-rect-command\x03\0\x0e\x01q\x03\x09fill-\
-rect\x01\x0d\0\x0bstroke-rect\x01\x0f\0\x04text\x01\x09\0\x04\0\x0cdraw-command\x03\
-\0\x10\x01r\x03\x05widthy\x06heighty\x05vsync\x7f\x04\0\x0fsurface-options\x03\0\
-\x12\x03\0\x15krate:gfx/types@0.1.0\x05(\x02\x03\0\x15\x05color\x02\x03\0\x15\x0c\
-draw-command\x02\x03\0\x15\x09gfx-error\x01B\x0f\x02\x03\x02\x01)\x04\0\x05color\
-\x03\0\0\x02\x03\x02\x01*\x04\0\x0cdraw-command\x03\0\x02\x02\x03\x02\x01+\x04\0\
-\x09gfx-error\x03\0\x04\x01j\x01w\x01\x05\x01@\x02\x06windoww\x06widgetw\0\x06\x04\
-\0\x04bind\x01\x07\x01j\0\x01\x05\x01@\x02\x06canvasw\x05color\x01\0\x08\x04\0\x05\
-clear\x01\x09\x01p\x03\x01@\x02\x06canvasw\x08commands\x0a\0\x08\x04\0\x06submit\
-\x01\x0b\x03\0\x18krate:gfx/canvas2d@0.1.0\x05,\x02\x03\0\x15\x0fsurface-options\
-\x01B\x0a\x02\x03\x02\x01+\x04\0\x09gfx-error\x03\0\0\x02\x03\x02\x01-\x04\0\x0f\
-surface-options\x03\0\x02\x01j\x01w\x01\x01\x01@\x03\x06windoww\x06widgetw\x07op\
-tions\x03\0\x04\x04\0\x0ecreate-surface\x01\x05\x01j\0\x01\x01\x01@\x01\x07surfa\
-cew\0\x06\x04\0\x07present\x01\x07\x03\0\x15krate:gfx/gpu3d@0.1.0\x05.\x01B\x06\x01\
-m\x02\x07pcm-s16\x07float32\x04\0\x0dsample-format\x03\0\0\x01r\x04\x0bsample-ra\
-tey\x08channels{\x06format\x01\x0dbuffer-framesy\x04\0\x0dstream-config\x03\0\x02\
-\x01q\x05\x11permission-denied\0\0\x0einvalid-stream\0\0\x12device-unavailable\0\
-\0\x0bunsupported\x01s\0\x08platform\x01s\0\x04\0\x0baudio-error\x03\0\x04\x03\0\
-\x17krate:audio/types@0.1.0\x05/\x02\x03\0\x18\x0baudio-error\x02\x03\0\x18\x0ds\
-tream-config\x01B\x0f\x02\x03\x02\x010\x04\0\x0baudio-error\x03\0\0\x02\x03\x02\x01\
-1\x04\0\x0dstream-config\x03\0\x02\x01j\x01w\x01\x01\x01@\x01\x06config\x03\0\x04\
-\x04\0\x04open\x01\x05\x01j\0\x01\x01\x01@\x01\x09stream-idw\0\x06\x04\0\x05star\
-t\x01\x07\x04\0\x04stop\x01\x07\x01p}\x01j\x01y\x01\x01\x01@\x02\x09stream-idw\x05\
-bytes\x08\0\x09\x04\0\x05write\x01\x0a\x03\0\x1akrate:audio/playback@0.1.0\x052\x01\
-B\x0f\x02\x03\x02\x010\x04\0\x0baudio-error\x03\0\0\x02\x03\x02\x011\x04\0\x0dst\
-ream-config\x03\0\x02\x01j\x01w\x01\x01\x01@\x01\x06config\x03\0\x04\x04\0\x04op\
-en\x01\x05\x01j\0\x01\x01\x01@\x01\x09stream-idw\0\x06\x04\0\x05start\x01\x07\x04\
-\0\x04stop\x01\x07\x01p}\x01j\x01\x08\x01\x01\x01@\x02\x09stream-idw\x09max-byte\
-sy\0\x09\x04\0\x04read\x01\x0a\x03\0\x19krate:audio/capture@0.1.0\x053\x01@\0\0z\
-\x04\0\x03run\x014\x04\0\x13krate:app/gui@0.2.0\x04\0\x0b\x09\x01\0\x03gui\x03\0\
-\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit-component\x070.227.1\x10wit-bi\
-ndgen-rust\x060.41.0";
+image\x06canvas\x04\0\x0bwidget-kind\x03\0\x16\x01r\x02\x06cursory\x06anchory\x04\
+\0\x0btext-cursor\x03\0\x18\x01kv\x01r\x04\x05width\x1a\x06height\x1a\x04growv\x07\
+paddingv\x04\0\x05style\x03\0\x1b\x01ks\x01k\x7f\x01ky\x01k\x19\x01r\x0a\x02idw\x06\
+parent\x0c\x04kind\x17\x05label\x1d\x04role\x1d\x05style\x1c\x07checked\x1e\x05v\
+alue\x1a\x08selected\x1f\x0btext-cursor\x20\x04\0\x0bwidget-node\x03\0!\x01r\x03\
+\x02idw\x05labels\x07enabled\x7f\x04\0\x09menu-item\x03\0#\x01q\x0a\x0fclose-req\
+uested\x01w\0\x07resized\x01\x03\0\x10redraw-requested\x01w\0\x07pointer\x01\x0f\
+\0\x03key\x01\x13\0\x0atext-input\x01s\0\x0ctext-changed\x01\x11\0\x06action\x01\
+w\0\x0dfocus-changed\x01\x0c\0\x0dtheme-changed\x01\x07\0\x04\0\x05event\x03\0%\x03\
+\0\x14krate:ui/types@0.1.0\x05\x1b\x02\x03\0\x0e\x08ui-error\x02\x03\0\x0e\x0bwi\
+ndow-size\x02\x03\0\x0e\x0cwindow-state\x01B\x14\x02\x03\x02\x01\x1c\x04\0\x08ui\
+-error\x03\0\0\x02\x03\x02\x01\x1d\x04\0\x0bwindow-size\x03\0\x02\x02\x03\x02\x01\
+\x1e\x04\0\x0cwindow-state\x03\0\x04\x01j\x01w\x01\x01\x01@\x02\x05titles\x04siz\
+e\x03\0\x06\x04\0\x06create\x01\x07\x01j\0\x01\x01\x01@\x01\x06windoww\0\x08\x04\
+\0\x04show\x01\x09\x04\0\x05close\x01\x09\x01@\x02\x06windoww\x05titles\0\x08\x04\
+\0\x09set-title\x01\x0a\x01@\x02\x06windoww\x04size\x03\0\x08\x04\0\x08set-size\x01\
+\x0b\x01@\x02\x06windoww\x05state\x05\0\x08\x04\0\x09set-state\x01\x0c\x04\0\x0e\
+request-redraw\x01\x09\x03\0\x15krate:ui/window@0.1.0\x05\x1f\x02\x03\0\x0e\x0bw\
+idget-node\x01B\x0e\x02\x03\x02\x01\x1c\x04\0\x08ui-error\x03\0\0\x02\x03\x02\x01\
+\x20\x04\0\x0bwidget-node\x03\0\x02\x01j\0\x01\x01\x01@\x02\x06windoww\x04root\x03\
+\0\x04\x04\0\x08set-root\x01\x05\x01@\x02\x06windoww\x04node\x03\0\x04\x04\0\x0b\
+upsert-node\x01\x06\x01@\x02\x06windoww\x06widgetw\0\x04\x04\0\x0bremove-node\x01\
+\x07\x04\0\x0afocus-node\x01\x07\x01@\x03\x06windoww\x06widgetw\x07enabled\x7f\0\
+\x04\x04\0\x0bset-enabled\x01\x08\x03\0\x13krate:ui/tree@0.1.0\x05!\x02\x03\0\x0e\
+\x05event\x01B\x08\x02\x03\x02\x01\"\x04\0\x05event\x03\0\0\x01k\x01\x01@\0\0\x02\
+\x04\0\x04poll\x01\x03\x01ky\x01@\x01\x0etimeout-millis\x04\0\x02\x04\0\x04wait\x01\
+\x05\x03\0\x15krate:ui/events@0.1.0\x05#\x01B\x08\x02\x03\x02\x01\x1c\x04\0\x08u\
+i-error\x03\0\0\x01j\0\x01\x01\x01@\x03\x06windoww\x05titles\x04bodys\0\x02\x04\0\
+\x07message\x01\x03\x01j\x01\x7f\x01\x01\x01@\x03\x06windoww\x05titles\x04bodys\0\
+\x04\x04\0\x07confirm\x01\x05\x03\0\x15krate:ui/dialog@0.1.0\x05$\x01B\x08\x02\x03\
+\x02\x01\x1c\x04\0\x08ui-error\x03\0\0\x01j\x01s\x01\x01\x01@\0\0\x02\x04\0\x09r\
+ead-text\x01\x03\x01j\0\x01\x01\x01@\x01\x04texts\0\x04\x04\0\x0awrite-text\x01\x05\
+\x03\0\x18krate:ui/clipboard@0.1.0\x05%\x02\x03\0\x0e\x09menu-item\x01B\x08\x02\x03\
+\x02\x01&\x04\0\x09menu-item\x03\0\0\x02\x03\x02\x01\x1c\x04\0\x08ui-error\x03\0\
+\x02\x01p\x01\x01j\0\x01\x03\x01@\x02\x06windoww\x05items\x04\0\x05\x04\0\x09set\
+-items\x01\x06\x03\0\x13krate:ui/menu@0.1.0\x05'\x01B\x14\x01r\x04\x01rv\x01gv\x01\
+bv\x01av\x04\0\x05color\x03\0\0\x01r\x02\x01xv\x01yv\x04\0\x05point\x03\0\x02\x01\
+r\x02\x05widthv\x06heightv\x04\0\x04size\x03\0\x04\x01r\x04\x01xv\x01yv\x05width\
+v\x06heightv\x04\0\x04rect\x03\0\x06\x01r\x05\x04texts\x06origin\x03\x0bfont-fam\
+ilys\x09font-sizev\x05color\x01\x04\0\x08text-run\x03\0\x08\x01q\x04\x11permissi\
+on-denied\0\0\x0einvalid-target\0\0\x0bunsupported\x01s\0\x08platform\x01s\0\x04\
+\0\x09gfx-error\x03\0\x0a\x01r\x02\x04rect\x07\x05color\x01\x04\0\x11fill-rect-c\
+ommand\x03\0\x0c\x01r\x03\x04rect\x07\x05color\x01\x05widthv\x04\0\x13stroke-rec\
+t-command\x03\0\x0e\x01q\x03\x09fill-rect\x01\x0d\0\x0bstroke-rect\x01\x0f\0\x04\
+text\x01\x09\0\x04\0\x0cdraw-command\x03\0\x10\x01r\x03\x05widthy\x06heighty\x05\
+vsync\x7f\x04\0\x0fsurface-options\x03\0\x12\x03\0\x15krate:gfx/types@0.1.0\x05(\
+\x02\x03\0\x15\x05color\x02\x03\0\x15\x0cdraw-command\x02\x03\0\x15\x09gfx-error\
+\x01B\x0f\x02\x03\x02\x01)\x04\0\x05color\x03\0\0\x02\x03\x02\x01*\x04\0\x0cdraw\
+-command\x03\0\x02\x02\x03\x02\x01+\x04\0\x09gfx-error\x03\0\x04\x01j\x01w\x01\x05\
+\x01@\x02\x06windoww\x06widgetw\0\x06\x04\0\x04bind\x01\x07\x01j\0\x01\x05\x01@\x02\
+\x06canvasw\x05color\x01\0\x08\x04\0\x05clear\x01\x09\x01p\x03\x01@\x02\x06canva\
+sw\x08commands\x0a\0\x08\x04\0\x06submit\x01\x0b\x03\0\x18krate:gfx/canvas2d@0.1\
+.0\x05,\x02\x03\0\x15\x0fsurface-options\x01B\x0a\x02\x03\x02\x01+\x04\0\x09gfx-\
+error\x03\0\0\x02\x03\x02\x01-\x04\0\x0fsurface-options\x03\0\x02\x01j\x01w\x01\x01\
+\x01@\x03\x06windoww\x06widgetw\x07options\x03\0\x04\x04\0\x0ecreate-surface\x01\
+\x05\x01j\0\x01\x01\x01@\x01\x07surfacew\0\x06\x04\0\x07present\x01\x07\x03\0\x15\
+krate:gfx/gpu3d@0.1.0\x05.\x01B\x06\x01m\x02\x07pcm-s16\x07float32\x04\0\x0dsamp\
+le-format\x03\0\0\x01r\x04\x0bsample-ratey\x08channels{\x06format\x01\x0dbuffer-\
+framesy\x04\0\x0dstream-config\x03\0\x02\x01q\x05\x11permission-denied\0\0\x0ein\
+valid-stream\0\0\x12device-unavailable\0\0\x0bunsupported\x01s\0\x08platform\x01\
+s\0\x04\0\x0baudio-error\x03\0\x04\x03\0\x17krate:audio/types@0.1.0\x05/\x02\x03\
+\0\x18\x0baudio-error\x02\x03\0\x18\x0dstream-config\x01B\x0f\x02\x03\x02\x010\x04\
+\0\x0baudio-error\x03\0\0\x02\x03\x02\x011\x04\0\x0dstream-config\x03\0\x02\x01j\
+\x01w\x01\x01\x01@\x01\x06config\x03\0\x04\x04\0\x04open\x01\x05\x01j\0\x01\x01\x01\
+@\x01\x09stream-idw\0\x06\x04\0\x05start\x01\x07\x04\0\x04stop\x01\x07\x01p}\x01\
+j\x01y\x01\x01\x01@\x02\x09stream-idw\x05bytes\x08\0\x09\x04\0\x05write\x01\x0a\x03\
+\0\x1akrate:audio/playback@0.1.0\x052\x01B\x0f\x02\x03\x02\x010\x04\0\x0baudio-e\
+rror\x03\0\0\x02\x03\x02\x011\x04\0\x0dstream-config\x03\0\x02\x01j\x01w\x01\x01\
+\x01@\x01\x06config\x03\0\x04\x04\0\x04open\x01\x05\x01j\0\x01\x01\x01@\x01\x09s\
+tream-idw\0\x06\x04\0\x05start\x01\x07\x04\0\x04stop\x01\x07\x01p}\x01j\x01\x08\x01\
+\x01\x01@\x02\x09stream-idw\x09max-bytesy\0\x09\x04\0\x04read\x01\x0a\x03\0\x19k\
+rate:audio/capture@0.1.0\x053\x01@\0\0z\x04\0\x03run\x014\x04\0\x13krate:app/gui\
+@0.2.0\x04\0\x0b\x09\x01\0\x03gui\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\
+\x0dwit-component\x070.227.1\x10wit-bindgen-rust\x060.41.0";
 #[inline(never)]
 #[doc(hidden)]
 pub fn __link_custom_section_describing_imports() {

--- a/apps/krate-hello-gui/src/lib.rs
+++ b/apps/krate-hello-gui/src/lib.rs
@@ -73,6 +73,7 @@ fn stack_root() -> types::WidgetNode {
         checked: None,
         value: None,
         selected: None,
+        text_cursor: None,
     }
 }
 
@@ -92,6 +93,7 @@ fn click_button() -> types::WidgetNode {
         checked: None,
         value: None,
         selected: None,
+        text_cursor: None,
     }
 }
 
@@ -111,6 +113,7 @@ fn text_field(label: &str) -> types::WidgetNode {
         checked: None,
         value: None,
         selected: None,
+        text_cursor: None,
     }
 }
 
@@ -130,6 +133,7 @@ fn scroll_area() -> types::WidgetNode {
         checked: None,
         value: None,
         selected: None,
+        text_cursor: None,
     }
 }
 
@@ -149,6 +153,7 @@ fn scroll_line(index: usize) -> types::WidgetNode {
         checked: None,
         value: None,
         selected: None,
+        text_cursor: None,
     }
 }
 
@@ -178,6 +183,7 @@ fn pick_list(selected: Option<u32>) -> types::WidgetNode {
         checked: None,
         value: None,
         selected,
+        text_cursor: None,
     }
 }
 
@@ -197,6 +203,7 @@ fn pick_row(index: usize) -> types::WidgetNode {
         checked: None,
         value: None,
         selected: None,
+        text_cursor: None,
     }
 }
 
@@ -216,6 +223,7 @@ fn robot_checkbox(checked: bool) -> types::WidgetNode {
         checked: Some(checked),
         value: None,
         selected: None,
+        text_cursor: None,
     }
 }
 
@@ -235,6 +243,7 @@ fn typing_progress(fraction: f32) -> types::WidgetNode {
         checked: None,
         value: Some(if fraction > 1.0 { 1.0 } else { fraction }),
         selected: None,
+        text_cursor: None,
     }
 }
 

--- a/apps/krate-notes/manifest.toml
+++ b/apps/krate-notes/manifest.toml
@@ -29,3 +29,17 @@ required = true
 cap = "fs.write:./notes/**"
 rationale = "Save the note you are editing"
 required = true
+
+# Cut/Copy/Paste on the drawn hosts (Linux, Windows) round-trip through the OS
+# clipboard. Optional on purpose: deny it and the app still opens, types, and
+# saves — only Cut/Copy/Paste go quiet. macOS uses its native control's own
+# clipboard and does not need these.
+[[capabilities]]
+cap = "ui.clipboard:read"
+rationale = "Paste text into a note"
+required = false
+
+[[capabilities]]
+cap = "ui.clipboard:write"
+rationale = "Copy or cut text from a note"
+required = false

--- a/apps/krate-notes/src/bindings.rs
+++ b/apps/krate-notes/src/bindings.rs
@@ -5494,6 +5494,33 @@ pub mod krate {
                     }
                 }
             }
+            /// Caret and selection inside a text widget, as byte offsets into its label.
+            ///
+            /// Hosts that paint their own text (Linux, Windows) have no native control to
+            /// hold a caret, so an app that implements editing itself reports where the
+            /// caret and selection sit and the painter draws them. `cursor` is the caret;
+            /// `anchor` is the other end of the selection. Equal offsets mean no
+            /// selection, just a caret. Hosts that lower to a real OS control ignore this:
+            /// the control owns its own caret.
+            #[repr(C)]
+            #[derive(Clone, Copy)]
+            pub struct TextCursor {
+                /// Caret position as a byte offset into the label, clamped to its length.
+                pub cursor: u32,
+                /// The other end of the selection. Equal to `cursor` means no selection.
+                pub anchor: u32,
+            }
+            impl ::core::fmt::Debug for TextCursor {
+                fn fmt(
+                    &self,
+                    f: &mut ::core::fmt::Formatter<'_>,
+                ) -> ::core::fmt::Result {
+                    f.debug_struct("TextCursor")
+                        .field("cursor", &self.cursor)
+                        .field("anchor", &self.anchor)
+                        .finish()
+                }
+            }
             /// Minimal style block for the first widget protocol draft.
             #[repr(C)]
             #[derive(Clone, Copy)]
@@ -5542,6 +5569,9 @@ pub mod krate {
                 /// Zero-based index of the selected child, for selectable container
                 /// kinds (list-view, tree-view). Out-of-range indices are rejected.
                 pub selected: Option<u32>,
+                /// Caret and selection for a text widget the app edits itself, drawn by
+                /// painting hosts. `none` leaves text caretless, as a passive label.
+                pub text_cursor: Option<TextCursor>,
             }
             impl ::core::fmt::Debug for WidgetNode {
                 fn fmt(
@@ -5558,6 +5588,7 @@ pub mod krate {
                         .field("checked", &self.checked)
                         .field("value", &self.value)
                         .field("selected", &self.selected)
+                        .field("text-cursor", &self.text_cursor)
                         .finish()
                 }
             }
@@ -6360,11 +6391,11 @@ pub mod krate {
                     struct RetArea(
                         [::core::mem::MaybeUninit<
                             u8,
-                        >; 72 + 8 * ::core::mem::size_of::<*const u8>()],
+                        >; 96 + 6 * ::core::mem::size_of::<*const u8>()],
                     );
                     let mut ret_area = RetArea(
-                        [::core::mem::MaybeUninit::uninit(); 72
-                            + 8 * ::core::mem::size_of::<*const u8>()],
+                        [::core::mem::MaybeUninit::uninit(); 96
+                            + 6 * ::core::mem::size_of::<*const u8>()],
                     );
                     let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                     *ptr0.add(0).cast::<i64>() = _rt::as_i64(&window);
@@ -6378,6 +6409,7 @@ pub mod krate {
                         checked: checked1,
                         value: value1,
                         selected: selected1,
+                        text_cursor: text_cursor1,
                     } = root;
                     *ptr0.add(8).cast::<i64>() = _rt::as_i64(id1);
                     match parent1 {
@@ -6522,79 +6554,101 @@ pub mod krate {
                                 .cast::<u8>() = (0i32) as u8;
                         }
                     };
-                    let ptr5 = ret_area.0.as_mut_ptr().cast::<u8>();
+                    match text_cursor1 {
+                        Some(e) => {
+                            *ptr0
+                                .add(76 + 7 * ::core::mem::size_of::<*const u8>())
+                                .cast::<u8>() = (1i32) as u8;
+                            let super::super::super::krate::ui::types::TextCursor {
+                                cursor: cursor5,
+                                anchor: anchor5,
+                            } = e;
+                            *ptr0
+                                .add(80 + 7 * ::core::mem::size_of::<*const u8>())
+                                .cast::<i32>() = _rt::as_i32(cursor5);
+                            *ptr0
+                                .add(84 + 7 * ::core::mem::size_of::<*const u8>())
+                                .cast::<i32>() = _rt::as_i32(anchor5);
+                        }
+                        None => {
+                            *ptr0
+                                .add(76 + 7 * ::core::mem::size_of::<*const u8>())
+                                .cast::<u8>() = (0i32) as u8;
+                        }
+                    };
+                    let ptr6 = ret_area.0.as_mut_ptr().cast::<u8>();
                     #[cfg(target_arch = "wasm32")]
                     #[link(wasm_import_module = "krate:ui/tree@0.1.0")]
                     unsafe extern "C" {
                         #[link_name = "set-root"]
-                        fn wit_import6(_: *mut u8, _: *mut u8);
+                        fn wit_import7(_: *mut u8, _: *mut u8);
                     }
                     #[cfg(not(target_arch = "wasm32"))]
-                    unsafe extern "C" fn wit_import6(_: *mut u8, _: *mut u8) {
+                    unsafe extern "C" fn wit_import7(_: *mut u8, _: *mut u8) {
                         unreachable!()
                     }
-                    unsafe { wit_import6(ptr0, ptr5) };
-                    let l7 = i32::from(*ptr5.add(0).cast::<u8>());
-                    let result16 = match l7 {
+                    unsafe { wit_import7(ptr0, ptr6) };
+                    let l8 = i32::from(*ptr6.add(0).cast::<u8>());
+                    let result17 = match l8 {
                         0 => {
                             let e = ();
                             Ok(e)
                         }
                         1 => {
                             let e = {
-                                let l8 = i32::from(
-                                    *ptr5.add(::core::mem::size_of::<*const u8>()).cast::<u8>(),
+                                let l9 = i32::from(
+                                    *ptr6.add(::core::mem::size_of::<*const u8>()).cast::<u8>(),
                                 );
-                                use super::super::super::krate::ui::types::UiError as V15;
-                                let v15 = match l8 {
-                                    0 => V15::PermissionDenied,
-                                    1 => V15::InvalidWindow,
-                                    2 => V15::InvalidWidget,
+                                use super::super::super::krate::ui::types::UiError as V16;
+                                let v16 = match l9 {
+                                    0 => V16::PermissionDenied,
+                                    1 => V16::InvalidWindow,
+                                    2 => V16::InvalidWidget,
                                     3 => {
-                                        let e15 = {
-                                            let l9 = *ptr5
+                                        let e16 = {
+                                            let l10 = *ptr6
                                                 .add(2 * ::core::mem::size_of::<*const u8>())
                                                 .cast::<*mut u8>();
-                                            let l10 = *ptr5
+                                            let l11 = *ptr6
                                                 .add(3 * ::core::mem::size_of::<*const u8>())
                                                 .cast::<usize>();
-                                            let len11 = l10;
-                                            let bytes11 = _rt::Vec::from_raw_parts(
-                                                l9.cast(),
-                                                len11,
-                                                len11,
+                                            let len12 = l11;
+                                            let bytes12 = _rt::Vec::from_raw_parts(
+                                                l10.cast(),
+                                                len12,
+                                                len12,
                                             );
-                                            _rt::string_lift(bytes11)
+                                            _rt::string_lift(bytes12)
                                         };
-                                        V15::Unsupported(e15)
+                                        V16::Unsupported(e16)
                                     }
                                     n => {
                                         debug_assert_eq!(n, 4, "invalid enum discriminant");
-                                        let e15 = {
-                                            let l12 = *ptr5
+                                        let e16 = {
+                                            let l13 = *ptr6
                                                 .add(2 * ::core::mem::size_of::<*const u8>())
                                                 .cast::<*mut u8>();
-                                            let l13 = *ptr5
+                                            let l14 = *ptr6
                                                 .add(3 * ::core::mem::size_of::<*const u8>())
                                                 .cast::<usize>();
-                                            let len14 = l13;
-                                            let bytes14 = _rt::Vec::from_raw_parts(
-                                                l12.cast(),
-                                                len14,
-                                                len14,
+                                            let len15 = l14;
+                                            let bytes15 = _rt::Vec::from_raw_parts(
+                                                l13.cast(),
+                                                len15,
+                                                len15,
                                             );
-                                            _rt::string_lift(bytes14)
+                                            _rt::string_lift(bytes15)
                                         };
-                                        V15::Platform(e15)
+                                        V16::Platform(e16)
                                     }
                                 };
-                                v15
+                                v16
                             };
                             Err(e)
                         }
                         _ => _rt::invalid_enum_discriminant(),
                     };
-                    result16
+                    result17
                 }
             }
             #[allow(unused_unsafe, clippy::all)]
@@ -6605,11 +6659,11 @@ pub mod krate {
                     struct RetArea(
                         [::core::mem::MaybeUninit<
                             u8,
-                        >; 72 + 8 * ::core::mem::size_of::<*const u8>()],
+                        >; 96 + 6 * ::core::mem::size_of::<*const u8>()],
                     );
                     let mut ret_area = RetArea(
-                        [::core::mem::MaybeUninit::uninit(); 72
-                            + 8 * ::core::mem::size_of::<*const u8>()],
+                        [::core::mem::MaybeUninit::uninit(); 96
+                            + 6 * ::core::mem::size_of::<*const u8>()],
                     );
                     let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                     *ptr0.add(0).cast::<i64>() = _rt::as_i64(&window);
@@ -6623,6 +6677,7 @@ pub mod krate {
                         checked: checked1,
                         value: value1,
                         selected: selected1,
+                        text_cursor: text_cursor1,
                     } = node;
                     *ptr0.add(8).cast::<i64>() = _rt::as_i64(id1);
                     match parent1 {
@@ -6767,79 +6822,101 @@ pub mod krate {
                                 .cast::<u8>() = (0i32) as u8;
                         }
                     };
-                    let ptr5 = ret_area.0.as_mut_ptr().cast::<u8>();
+                    match text_cursor1 {
+                        Some(e) => {
+                            *ptr0
+                                .add(76 + 7 * ::core::mem::size_of::<*const u8>())
+                                .cast::<u8>() = (1i32) as u8;
+                            let super::super::super::krate::ui::types::TextCursor {
+                                cursor: cursor5,
+                                anchor: anchor5,
+                            } = e;
+                            *ptr0
+                                .add(80 + 7 * ::core::mem::size_of::<*const u8>())
+                                .cast::<i32>() = _rt::as_i32(cursor5);
+                            *ptr0
+                                .add(84 + 7 * ::core::mem::size_of::<*const u8>())
+                                .cast::<i32>() = _rt::as_i32(anchor5);
+                        }
+                        None => {
+                            *ptr0
+                                .add(76 + 7 * ::core::mem::size_of::<*const u8>())
+                                .cast::<u8>() = (0i32) as u8;
+                        }
+                    };
+                    let ptr6 = ret_area.0.as_mut_ptr().cast::<u8>();
                     #[cfg(target_arch = "wasm32")]
                     #[link(wasm_import_module = "krate:ui/tree@0.1.0")]
                     unsafe extern "C" {
                         #[link_name = "upsert-node"]
-                        fn wit_import6(_: *mut u8, _: *mut u8);
+                        fn wit_import7(_: *mut u8, _: *mut u8);
                     }
                     #[cfg(not(target_arch = "wasm32"))]
-                    unsafe extern "C" fn wit_import6(_: *mut u8, _: *mut u8) {
+                    unsafe extern "C" fn wit_import7(_: *mut u8, _: *mut u8) {
                         unreachable!()
                     }
-                    unsafe { wit_import6(ptr0, ptr5) };
-                    let l7 = i32::from(*ptr5.add(0).cast::<u8>());
-                    let result16 = match l7 {
+                    unsafe { wit_import7(ptr0, ptr6) };
+                    let l8 = i32::from(*ptr6.add(0).cast::<u8>());
+                    let result17 = match l8 {
                         0 => {
                             let e = ();
                             Ok(e)
                         }
                         1 => {
                             let e = {
-                                let l8 = i32::from(
-                                    *ptr5.add(::core::mem::size_of::<*const u8>()).cast::<u8>(),
+                                let l9 = i32::from(
+                                    *ptr6.add(::core::mem::size_of::<*const u8>()).cast::<u8>(),
                                 );
-                                use super::super::super::krate::ui::types::UiError as V15;
-                                let v15 = match l8 {
-                                    0 => V15::PermissionDenied,
-                                    1 => V15::InvalidWindow,
-                                    2 => V15::InvalidWidget,
+                                use super::super::super::krate::ui::types::UiError as V16;
+                                let v16 = match l9 {
+                                    0 => V16::PermissionDenied,
+                                    1 => V16::InvalidWindow,
+                                    2 => V16::InvalidWidget,
                                     3 => {
-                                        let e15 = {
-                                            let l9 = *ptr5
+                                        let e16 = {
+                                            let l10 = *ptr6
                                                 .add(2 * ::core::mem::size_of::<*const u8>())
                                                 .cast::<*mut u8>();
-                                            let l10 = *ptr5
+                                            let l11 = *ptr6
                                                 .add(3 * ::core::mem::size_of::<*const u8>())
                                                 .cast::<usize>();
-                                            let len11 = l10;
-                                            let bytes11 = _rt::Vec::from_raw_parts(
-                                                l9.cast(),
-                                                len11,
-                                                len11,
+                                            let len12 = l11;
+                                            let bytes12 = _rt::Vec::from_raw_parts(
+                                                l10.cast(),
+                                                len12,
+                                                len12,
                                             );
-                                            _rt::string_lift(bytes11)
+                                            _rt::string_lift(bytes12)
                                         };
-                                        V15::Unsupported(e15)
+                                        V16::Unsupported(e16)
                                     }
                                     n => {
                                         debug_assert_eq!(n, 4, "invalid enum discriminant");
-                                        let e15 = {
-                                            let l12 = *ptr5
+                                        let e16 = {
+                                            let l13 = *ptr6
                                                 .add(2 * ::core::mem::size_of::<*const u8>())
                                                 .cast::<*mut u8>();
-                                            let l13 = *ptr5
+                                            let l14 = *ptr6
                                                 .add(3 * ::core::mem::size_of::<*const u8>())
                                                 .cast::<usize>();
-                                            let len14 = l13;
-                                            let bytes14 = _rt::Vec::from_raw_parts(
-                                                l12.cast(),
-                                                len14,
-                                                len14,
+                                            let len15 = l14;
+                                            let bytes15 = _rt::Vec::from_raw_parts(
+                                                l13.cast(),
+                                                len15,
+                                                len15,
                                             );
-                                            _rt::string_lift(bytes14)
+                                            _rt::string_lift(bytes15)
                                         };
-                                        V15::Platform(e15)
+                                        V16::Platform(e16)
                                     }
                                 };
-                                v15
+                                v16
                             };
                             Err(e)
                         }
                         _ => _rt::invalid_enum_discriminant(),
                     };
-                    result16
+                    result17
                 }
             }
             #[allow(unused_unsafe, clippy::all)]
@@ -8548,8 +8625,8 @@ pub(crate) use __export_gui_impl as export;
 )]
 #[doc(hidden)]
 #[allow(clippy::octal_escapes)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 6598] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xcc2\x01A\x02\x01AQ\x01\
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 6650] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\x803\x01A\x02\x01AQ\x01\
 B\x04\x01m\x05\x05trace\x05debug\x04info\x04warn\x05error\x04\0\x09log-level\x03\
 \0\0\x01q\x05\x06closed\0\0\x0binterrupted\0\0\x0eunexpected-eof\0\0\x0cinvalid-\
 utf8\0\0\x05other\x01s\0\x04\0\x08io-error\x03\0\x02\x03\0\x14krate:io/types@0.1\
@@ -8614,7 +8691,7 @@ ale/info@0.1.0\x05\x17\x02\x03\0\x0b\x0adate-style\x02\x03\0\x0b\x0cnumber-style
 \0\x0adate-style\x03\0\x02\x02\x03\x02\x01\x19\x04\0\x0cnumber-style\x03\0\x04\x01\
 @\x04\x06millisw\x02tzs\x05style\x03\x03loc\x01\0s\x04\0\x0bformat-date\x01\x06\x01\
 @\x03\x05valueu\x05style\x05\x03loc\x01\0s\x04\0\x0dformat-number\x01\x07\x03\0\x19\
-krate:locale/format@0.1.0\x05\x1a\x01B$\x01m\x04\x06normal\x09minimized\x09maxim\
+krate:locale/format@0.1.0\x05\x1a\x01B'\x01m\x04\x06normal\x09minimized\x09maxim\
 ized\x0afullscreen\x04\0\x0cwindow-state\x03\0\0\x01r\x02\x05widthy\x06heighty\x04\
 \0\x0bwindow-size\x03\0\x02\x01r\x04\x01xv\x01yv\x05widthv\x06heightv\x04\0\x04r\
 ect\x03\0\x04\x01m\x03\x05light\x04dark\x07unknown\x04\0\x05theme\x03\0\x06\x01m\
@@ -8628,14 +8705,15 @@ oww\x06widget\x0c\x03keys\x07pressed\x7f\x09modifiers\x0b\x04\0\x09key-event\x03
 \0\0\x0bunsupported\x01s\0\x08platform\x01s\0\x04\0\x08ui-error\x03\0\x14\x01m\x11\
 \x05stack\x04grid\x06scroll\x04tabs\x06button\x08checkbox\x05radio\x06switch\x06\
 slider\x08progress\x04text\x0atext-field\x09text-area\x09list-view\x09tree-view\x05\
-image\x06canvas\x04\0\x0bwidget-kind\x03\0\x16\x01kv\x01r\x04\x05width\x18\x06he\
-ight\x18\x04growv\x07paddingv\x04\0\x05style\x03\0\x19\x01ks\x01k\x7f\x01ky\x01r\
-\x09\x02idw\x06parent\x0c\x04kind\x17\x05label\x1b\x04role\x1b\x05style\x1a\x07c\
-hecked\x1c\x05value\x18\x08selected\x1d\x04\0\x0bwidget-node\x03\0\x1e\x01r\x03\x02\
-idw\x05labels\x07enabled\x7f\x04\0\x09menu-item\x03\0\x20\x01q\x0a\x0fclose-requ\
-ested\x01w\0\x07resized\x01\x03\0\x10redraw-requested\x01w\0\x07pointer\x01\x0f\0\
-\x03key\x01\x13\0\x0atext-input\x01s\0\x0ctext-changed\x01\x11\0\x06action\x01w\0\
-\x0dfocus-changed\x01\x0c\0\x0dtheme-changed\x01\x07\0\x04\0\x05event\x03\0\"\x03\
+image\x06canvas\x04\0\x0bwidget-kind\x03\0\x16\x01r\x02\x06cursory\x06anchory\x04\
+\0\x0btext-cursor\x03\0\x18\x01kv\x01r\x04\x05width\x1a\x06height\x1a\x04growv\x07\
+paddingv\x04\0\x05style\x03\0\x1b\x01ks\x01k\x7f\x01ky\x01k\x19\x01r\x0a\x02idw\x06\
+parent\x0c\x04kind\x17\x05label\x1d\x04role\x1d\x05style\x1c\x07checked\x1e\x05v\
+alue\x1a\x08selected\x1f\x0btext-cursor\x20\x04\0\x0bwidget-node\x03\0!\x01r\x03\
+\x02idw\x05labels\x07enabled\x7f\x04\0\x09menu-item\x03\0#\x01q\x0a\x0fclose-req\
+uested\x01w\0\x07resized\x01\x03\0\x10redraw-requested\x01w\0\x07pointer\x01\x0f\
+\0\x03key\x01\x13\0\x0atext-input\x01s\0\x0ctext-changed\x01\x11\0\x06action\x01\
+w\0\x0dfocus-changed\x01\x0c\0\x0dtheme-changed\x01\x07\0\x04\0\x05event\x03\0%\x03\
 \0\x14krate:ui/types@0.1.0\x05\x1b\x02\x03\0\x0e\x08ui-error\x02\x03\0\x0e\x0bwi\
 ndow-size\x02\x03\0\x0e\x0cwindow-state\x01B\x14\x02\x03\x02\x01\x1c\x04\0\x08ui\
 -error\x03\0\0\x02\x03\x02\x01\x1d\x04\0\x0bwindow-size\x03\0\x02\x02\x03\x02\x01\

--- a/apps/krate-notes/src/lib.rs
+++ b/apps/krate-notes/src/lib.rs
@@ -17,7 +17,7 @@ mod bindings;
 
 use bindings::krate::fs::files::{self, OpenMode};
 use bindings::krate::io::{args, stdio};
-use bindings::krate::ui::{events, tree, types, window};
+use bindings::krate::ui::{clipboard, events, tree, types, window};
 
 const ROOT_ID: u64 = 1;
 /// The left column wraps a header label and the note list. Child order is
@@ -76,22 +76,76 @@ const WAIT_ROUND_MILLIS: u32 = 50;
 
 struct Component;
 
-/// A fixed-capacity text buffer that never panics and never allocates.
+/// How many edit states undo/redo can walk back through. Fixed so the editor
+/// allocates nothing: the two stacks below are inline arrays. A note is small
+/// and a demo session is short, so a shallow history is plenty; the point is
+/// that undo works at all on the drawn path, not that it is unbounded.
+const HISTORY_DEPTH: usize = 32;
+
+/// One captured edit state: the full text plus where the cursor and selection
+/// sat. Undo restores all three so the caret lands back where the person was.
+#[derive(Clone, Copy)]
+struct Snapshot {
+    bytes: [u8; NOTE_CAPACITY],
+    len: usize,
+    cursor: usize,
+    anchor: usize,
+}
+
+/// A fixed-capacity, allocation-free, panic-free text editor.
+///
+/// The drawn path (Linux, Windows) paints its own text, so unlike the macOS
+/// native control, every editing behavior — caret movement, selection, cut,
+/// copy, paste, undo, redo — is implemented here in the guest against the raw
+/// byte buffer. Text is treated as bytes: `TextInput` on the drawn path is
+/// filtered to ASCII, so a byte index is always a character boundary and the
+/// caret arithmetic below is exact.
 struct NoteBuffer {
     bytes: [u8; NOTE_CAPACITY],
     len: usize,
+    /// Caret position as a byte offset in `0..=len`.
+    cursor: usize,
+    /// The other end of the selection. Equal to `cursor` means no selection;
+    /// otherwise the selection spans `[min, max)` of the two.
+    anchor: usize,
+    /// States to restore on undo, and the states redo can return to. Both are
+    /// bounded ring-free stacks: pushing past the top drops the oldest state.
+    undo: [Snapshot; HISTORY_DEPTH],
+    undo_len: usize,
+    redo: [Snapshot; HISTORY_DEPTH],
+    redo_len: usize,
 }
 
 impl NoteBuffer {
     const fn new() -> Self {
+        let empty = Snapshot {
+            bytes: [0; NOTE_CAPACITY],
+            len: 0,
+            cursor: 0,
+            anchor: 0,
+        };
         Self {
             bytes: [0; NOTE_CAPACITY],
             len: 0,
+            cursor: 0,
+            anchor: 0,
+            undo: [empty; HISTORY_DEPTH],
+            undo_len: 0,
+            redo: [empty; HISTORY_DEPTH],
+            redo_len: 0,
         }
     }
 
+    // ---- state used by load/save/quick-seed (unchanged call sites) ----
+
+    /// Reset to an empty note. Used when loading a file or making a new note,
+    /// which is a fresh document, so history is cleared too.
     fn clear(&mut self) {
         self.len = 0;
+        self.cursor = 0;
+        self.anchor = 0;
+        self.undo_len = 0;
+        self.redo_len = 0;
     }
 
     fn push_str(&mut self, text: &str) {
@@ -100,21 +154,306 @@ impl NoteBuffer {
         }
     }
 
+    /// Append one byte at the end and keep the caret trailing it. Used by the
+    /// file loader and the quick-run seed, which fill the buffer before the
+    /// person starts editing, so this never touches history.
     fn push(&mut self, byte: u8) {
         if let Some(slot) = self.bytes.get_mut(self.len) {
             *slot = byte;
             self.len += 1;
+            self.cursor = self.len;
+            self.anchor = self.len;
         }
-    }
-
-    fn pop(&mut self) {
-        self.len = self.len.saturating_sub(1);
     }
 
     fn as_str(&self) -> &str {
         let slice = self.bytes.get(..self.len).unwrap_or(&[]);
         core::str::from_utf8(slice).unwrap_or("")
     }
+
+    // ---- selection ----
+
+    /// Selection bounds as `[start, end)` in byte offsets, start <= end.
+    fn selection(&self) -> (usize, usize) {
+        if self.cursor <= self.anchor {
+            (self.cursor, self.anchor)
+        } else {
+            (self.anchor, self.cursor)
+        }
+    }
+
+    fn has_selection(&self) -> bool {
+        self.cursor != self.anchor
+    }
+
+    /// The selected text, or the empty string when nothing is selected. Copy
+    /// and Cut hand this to the clipboard.
+    fn selected_text(&self) -> &str {
+        let (start, end) = self.selection();
+        let slice = self.bytes.get(start..end).unwrap_or(&[]);
+        core::str::from_utf8(slice).unwrap_or("")
+    }
+
+    fn select_all(&mut self) {
+        self.anchor = 0;
+        self.cursor = self.len;
+    }
+
+    // ---- caret movement. `extend` keeps the anchor to grow a selection. ----
+
+    fn move_left(&mut self, extend: bool) {
+        // Moving without extending collapses an existing selection to its left
+        // edge rather than stepping past it — the behavior every editor has.
+        if !extend && self.has_selection() {
+            let (start, _) = self.selection();
+            self.cursor = start;
+        } else {
+            self.cursor = self.cursor.saturating_sub(1);
+        }
+        if !extend {
+            self.anchor = self.cursor;
+        }
+    }
+
+    fn move_right(&mut self, extend: bool) {
+        if !extend && self.has_selection() {
+            let (_, end) = self.selection();
+            self.cursor = end;
+        } else {
+            self.cursor = (self.cursor + 1).min(self.len);
+        }
+        if !extend {
+            self.anchor = self.cursor;
+        }
+    }
+
+    fn move_home(&mut self, extend: bool) {
+        self.cursor = 0;
+        if !extend {
+            self.anchor = 0;
+        }
+    }
+
+    fn move_end(&mut self, extend: bool) {
+        self.cursor = self.len;
+        if !extend {
+            self.anchor = self.len;
+        }
+    }
+
+    // ---- history ----
+
+    /// Capture the current state onto the undo stack before a mutation, and
+    /// drop any redo future — editing after an undo forks history, so the old
+    /// redo path no longer applies.
+    fn record(&mut self) {
+        let snap = Snapshot {
+            bytes: self.bytes,
+            len: self.len,
+            cursor: self.cursor,
+            anchor: self.anchor,
+        };
+        push_snapshot(&mut self.undo, &mut self.undo_len, snap);
+        self.redo_len = 0;
+    }
+
+    fn restore(&mut self, snap: Snapshot) {
+        self.bytes = snap.bytes;
+        self.len = snap.len;
+        self.cursor = snap.cursor.min(snap.len);
+        self.anchor = snap.anchor.min(snap.len);
+    }
+
+    /// Step back one edit. The current state is pushed onto redo first so it
+    /// can be reached again. Returns whether anything changed.
+    fn undo(&mut self) -> bool {
+        let Some(prev) = pop_snapshot(&self.undo, &mut self.undo_len) else {
+            return false;
+        };
+        let current = Snapshot {
+            bytes: self.bytes,
+            len: self.len,
+            cursor: self.cursor,
+            anchor: self.anchor,
+        };
+        push_snapshot(&mut self.redo, &mut self.redo_len, current);
+        self.restore(prev);
+        true
+    }
+
+    fn redo(&mut self) -> bool {
+        let Some(next) = pop_snapshot(&self.redo, &mut self.redo_len) else {
+            return false;
+        };
+        let current = Snapshot {
+            bytes: self.bytes,
+            len: self.len,
+            cursor: self.cursor,
+            anchor: self.anchor,
+        };
+        push_snapshot(&mut self.undo, &mut self.undo_len, current);
+        self.restore(next);
+        true
+    }
+
+    // ---- editing ops (each records history first) ----
+
+    /// Remove the current selection in place, leaving the caret where it began.
+    /// Returns false when there was nothing selected.
+    fn delete_selection_raw(&mut self) -> bool {
+        if !self.has_selection() {
+            return false;
+        }
+        let (start, end) = self.selection();
+        let removed = end - start;
+        // Shift the tail after the selection left over the hole it leaves.
+        let mut i = end;
+        while i < self.len {
+            if let Some(src) = self.bytes.get(i).copied() {
+                if let Some(slot) = self.bytes.get_mut(start + (i - end)) {
+                    *slot = src;
+                }
+            }
+            i += 1;
+        }
+        self.len = self.len.saturating_sub(removed);
+        self.cursor = start;
+        self.anchor = start;
+        true
+    }
+
+    /// Insert text at the caret, replacing any selection first. Silently stops
+    /// at capacity rather than growing or panicking.
+    fn insert_str(&mut self, text: &str) {
+        self.record();
+        self.delete_selection_raw();
+        for byte in text.as_bytes() {
+            // The drawn host only forwards ASCII text input, but guard anyway:
+            // a non-ASCII byte would break the byte-equals-char assumption.
+            if !byte.is_ascii() {
+                continue;
+            }
+            self.insert_byte(*byte);
+        }
+    }
+
+    /// Insert one byte at the caret, shifting the tail right. No-op at capacity.
+    fn insert_byte(&mut self, byte: u8) {
+        if self.len >= NOTE_CAPACITY {
+            return;
+        }
+        // Shift everything from the caret onward one slot to the right.
+        let mut i = self.len;
+        while i > self.cursor {
+            if let Some(src) = self.bytes.get(i - 1).copied() {
+                if let Some(slot) = self.bytes.get_mut(i) {
+                    *slot = src;
+                }
+            }
+            i -= 1;
+        }
+        if let Some(slot) = self.bytes.get_mut(self.cursor) {
+            *slot = byte;
+            self.len += 1;
+            self.cursor += 1;
+            self.anchor = self.cursor;
+        }
+    }
+
+    /// Backspace: delete the selection if any, otherwise the byte before the
+    /// caret.
+    fn backspace(&mut self) {
+        self.record();
+        if self.delete_selection_raw() {
+            return;
+        }
+        if self.cursor == 0 {
+            // Nothing to delete; drop the snapshot we just took so a no-op
+            // backspace does not consume an undo step.
+            self.undo_len = self.undo_len.saturating_sub(1);
+            return;
+        }
+        self.cursor -= 1;
+        let mut i = self.cursor;
+        while i + 1 < self.len {
+            if let Some(src) = self.bytes.get(i + 1).copied() {
+                if let Some(slot) = self.bytes.get_mut(i) {
+                    *slot = src;
+                }
+            }
+            i += 1;
+        }
+        self.len = self.len.saturating_sub(1);
+        self.anchor = self.cursor;
+    }
+
+    /// Forward delete (the Delete key): the selection if any, else the byte at
+    /// the caret.
+    fn delete_forward(&mut self) {
+        self.record();
+        if self.delete_selection_raw() {
+            return;
+        }
+        if self.cursor >= self.len {
+            self.undo_len = self.undo_len.saturating_sub(1);
+            return;
+        }
+        let mut i = self.cursor;
+        while i + 1 < self.len {
+            if let Some(src) = self.bytes.get(i + 1).copied() {
+                if let Some(slot) = self.bytes.get_mut(i) {
+                    *slot = src;
+                }
+            }
+            i += 1;
+        }
+        self.len = self.len.saturating_sub(1);
+        self.anchor = self.cursor;
+    }
+
+    /// Delete the current selection as one undoable step. Cut is Copy (which
+    /// reads `selected_text` first) followed by this. No-op with no selection,
+    /// and then it does not consume an undo step.
+    fn delete_selection(&mut self) {
+        if !self.has_selection() {
+            return;
+        }
+        self.record();
+        self.delete_selection_raw();
+    }
+}
+
+/// Push a snapshot onto a bounded stack. At capacity the oldest state slides
+/// out, so history stays shallow without ever allocating or panicking.
+fn push_snapshot(stack: &mut [Snapshot; HISTORY_DEPTH], len: &mut usize, snap: Snapshot) {
+    if *len < HISTORY_DEPTH {
+        if let Some(slot) = stack.get_mut(*len) {
+            *slot = snap;
+            *len += 1;
+        }
+        return;
+    }
+    // Full: drop index 0 by shifting everything down, then write the newest.
+    let mut i = 1;
+    while i < HISTORY_DEPTH {
+        if let Some(src) = stack.get(i).copied() {
+            if let Some(dst) = stack.get_mut(i - 1) {
+                *dst = src;
+            }
+        }
+        i += 1;
+    }
+    if let Some(slot) = stack.get_mut(HISTORY_DEPTH - 1) {
+        *slot = snap;
+    }
+}
+
+fn pop_snapshot(stack: &[Snapshot; HISTORY_DEPTH], len: &mut usize) -> Option<Snapshot> {
+    if *len == 0 {
+        return None;
+    }
+    *len -= 1;
+    stack.get(*len).copied()
 }
 
 /// Build an owned `String` without touching std's allocation-error handler.
@@ -137,7 +476,13 @@ fn pure_string_from_bytes(bytes: &[u8]) -> String {
         let layout = core::alloc::Layout::from_size_align_unchecked(len, 1);
         let ptr = std::alloc::alloc(layout);
         if ptr.is_null() {
-            core::arch::wasm32::unreachable()
+            // On the wasm target, trap without pulling in std's allocation-error
+            // handler (which drags the wasi import set into the component). Under
+            // a native test build there is no such constraint, so abort plainly.
+            #[cfg(target_arch = "wasm32")]
+            core::arch::wasm32::unreachable();
+            #[cfg(not(target_arch = "wasm32"))]
+            std::process::abort();
         }
         core::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr, len);
         String::from_raw_parts(ptr, len, len)
@@ -162,6 +507,7 @@ fn stack_root() -> types::WidgetNode {
         checked: None,
         value: None,
         selected: None,
+        text_cursor: None,
     }
 }
 
@@ -182,6 +528,7 @@ fn editor_column() -> types::WidgetNode {
         checked: None,
         value: None,
         selected: None,
+        text_cursor: None,
     }
 }
 
@@ -202,6 +549,7 @@ fn left_column() -> types::WidgetNode {
         checked: None,
         value: None,
         selected: None,
+        text_cursor: None,
     }
 }
 
@@ -223,6 +571,7 @@ fn sidebar_header() -> types::WidgetNode {
         checked: None,
         value: None,
         selected: None,
+        text_cursor: None,
     }
 }
 
@@ -243,6 +592,7 @@ fn sidebar(selected: Option<u32>) -> types::WidgetNode {
         checked: None,
         value: None,
         selected,
+        text_cursor: None,
     }
 }
 
@@ -264,16 +614,21 @@ fn note_row(index: usize) -> types::WidgetNode {
         checked: None,
         value: None,
         selected: None,
+        text_cursor: None,
     }
 }
 
 /// The editor. A TextArea wraps and fills from the top, unlike a field.
-fn editor(text: &str) -> types::WidgetNode {
+///
+/// `cursor` and `anchor` are byte offsets the drawn hosts use to paint the
+/// caret and selection. The macOS native control owns its own caret and
+/// ignores them, so passing them always is harmless there.
+fn editor(buffer: &NoteBuffer) -> types::WidgetNode {
     types::WidgetNode {
         id: EDITOR_ID,
         parent: Some(EDITOR_COLUMN_ID),
         kind: types::WidgetKind::TextArea,
-        label: Some(pure_string(text)),
+        label: Some(pure_string(buffer.as_str())),
         role: Some(pure_string("textbox")),
         style: types::Style {
             width: Some(460.0),
@@ -284,6 +639,10 @@ fn editor(text: &str) -> types::WidgetNode {
         checked: None,
         value: None,
         selected: None,
+        text_cursor: Some(types::TextCursor {
+            cursor: buffer.cursor as u32,
+            anchor: buffer.anchor as u32,
+        }),
     }
 }
 
@@ -303,6 +662,7 @@ fn status(text: &str) -> types::WidgetNode {
         checked: None,
         value: None,
         selected: None,
+        text_cursor: None,
     }
 }
 
@@ -324,6 +684,7 @@ fn new_note_row() -> types::WidgetNode {
         checked: None,
         value: None,
         selected: None,
+        text_cursor: None,
     }
 }
 
@@ -359,6 +720,169 @@ fn load_note(index: usize, buffer: &mut NoteBuffer) -> bool {
         }
     }
     true
+}
+
+/// What a drawn-path key press did, so the run loop knows what to re-lower.
+enum DrawnKeyOutcome {
+    /// The key was not one this editor handles.
+    Ignored,
+    /// Text changed; re-lower the editor and mark the note dirty.
+    Edited,
+    /// Only the caret or selection moved; re-lower to repaint it.
+    Moved,
+    /// The note was saved to disk.
+    Saved,
+    /// A save was attempted but the write was refused.
+    SaveDenied,
+}
+
+/// The command a drawn-path key press maps to, before any side effect runs.
+///
+/// Splitting translation from execution keeps the shortcut table — the part
+/// that must behave the same on every host — a pure function of the key and
+/// modifiers, with no clipboard, file, or binding calls in the way.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum KeyAction {
+    None,
+    SelectAll,
+    Copy,
+    Cut,
+    Paste,
+    Undo,
+    Redo,
+    Save,
+    Backspace,
+    DeleteForward,
+    MoveLeft { extend: bool },
+    MoveRight { extend: bool },
+    MoveHome { extend: bool },
+    MoveEnd { extend: bool },
+}
+
+/// Translate a key name and modifier state into an editing command.
+///
+/// This is the whole keyboard surface for the drawn hosts, and the one place
+/// platform shortcuts are decided. Editing shortcuts key off Control (Linux,
+/// Windows) or Meta/Command (macOS) via `chord`, so the byte-identical guest
+/// honors each platform's native modifier without knowing which host it runs
+/// on. Navigation keys (arrows, Home, End, Backspace, Delete) need no modifier;
+/// Shift on them extends the selection.
+fn classify_key(key: &str, control: bool, meta: bool, shift: bool) -> KeyAction {
+    let chord = control || meta;
+    if chord {
+        return match key {
+            "a" | "A" => KeyAction::SelectAll,
+            "c" | "C" => KeyAction::Copy,
+            "x" | "X" => KeyAction::Cut,
+            "v" | "V" => KeyAction::Paste,
+            // Redo is Cmd/Ctrl+Shift+Z; undo is the same chord without Shift.
+            // Ctrl+Y is the Windows habit for redo. Check Shift first so Z does
+            // not fall through to undo.
+            "z" | "Z" if shift => KeyAction::Redo,
+            "z" | "Z" => KeyAction::Undo,
+            "y" | "Y" => KeyAction::Redo,
+            "s" | "S" => KeyAction::Save,
+            _ => KeyAction::None,
+        };
+    }
+    match key {
+        "Backspace" => KeyAction::Backspace,
+        "Delete" => KeyAction::DeleteForward,
+        "ArrowLeft" => KeyAction::MoveLeft { extend: shift },
+        "ArrowRight" => KeyAction::MoveRight { extend: shift },
+        "Home" => KeyAction::MoveHome { extend: shift },
+        "End" => KeyAction::MoveEnd { extend: shift },
+        _ => KeyAction::None,
+    }
+}
+
+/// Run one drawn-path key press: translate it, then apply it to the buffer,
+/// performing the clipboard and file side effects the command needs.
+fn apply_drawn_key(buffer: &mut NoteBuffer, key: &types::KeyEvent, selected: usize) -> DrawnKeyOutcome {
+    let action = classify_key(
+        &key.key,
+        key.modifiers.control,
+        key.modifiers.meta,
+        key.modifiers.shift,
+    );
+    match action {
+        KeyAction::None => DrawnKeyOutcome::Ignored,
+        KeyAction::SelectAll => {
+            buffer.select_all();
+            DrawnKeyOutcome::Moved
+        }
+        // Cut/Copy/Paste round-trip through the host clipboard. A note denied
+        // `ui.clipboard` still types and saves — the calls just fail closed.
+        KeyAction::Copy => {
+            if buffer.has_selection() {
+                let _ = clipboard::write_text(buffer.selected_text());
+            }
+            DrawnKeyOutcome::Ignored
+        }
+        KeyAction::Cut => {
+            if buffer.has_selection() {
+                let _ = clipboard::write_text(buffer.selected_text());
+                buffer.delete_selection();
+                DrawnKeyOutcome::Edited
+            } else {
+                DrawnKeyOutcome::Ignored
+            }
+        }
+        KeyAction::Paste => {
+            if let Ok(text) = clipboard::read_text() {
+                if !text.is_empty() {
+                    buffer.insert_str(&text);
+                    return DrawnKeyOutcome::Edited;
+                }
+            }
+            DrawnKeyOutcome::Ignored
+        }
+        KeyAction::Undo => {
+            if buffer.undo() {
+                DrawnKeyOutcome::Edited
+            } else {
+                DrawnKeyOutcome::Ignored
+            }
+        }
+        KeyAction::Redo => {
+            if buffer.redo() {
+                DrawnKeyOutcome::Edited
+            } else {
+                DrawnKeyOutcome::Ignored
+            }
+        }
+        KeyAction::Save => {
+            if save_note(selected, buffer) {
+                DrawnKeyOutcome::Saved
+            } else {
+                DrawnKeyOutcome::SaveDenied
+            }
+        }
+        KeyAction::Backspace => {
+            buffer.backspace();
+            DrawnKeyOutcome::Edited
+        }
+        KeyAction::DeleteForward => {
+            buffer.delete_forward();
+            DrawnKeyOutcome::Edited
+        }
+        KeyAction::MoveLeft { extend } => {
+            buffer.move_left(extend);
+            DrawnKeyOutcome::Moved
+        }
+        KeyAction::MoveRight { extend } => {
+            buffer.move_right(extend);
+            DrawnKeyOutcome::Moved
+        }
+        KeyAction::MoveHome { extend } => {
+            buffer.move_home(extend);
+            DrawnKeyOutcome::Moved
+        }
+        KeyAction::MoveEnd { extend } => {
+            buffer.move_end(extend);
+            DrawnKeyOutcome::Moved
+        }
+    }
 }
 
 /// Save the editor buffer back to the granted directory.
@@ -410,7 +934,7 @@ impl bindings::Guest for Component {
             || tree::upsert_node(win, &sidebar_header()).is_err()
             || tree::upsert_node(win, &sidebar(Some(selected))).is_err()
             || tree::upsert_node(win, &editor_column()).is_err()
-            || tree::upsert_node(win, &editor(buffer.as_str())).is_err()
+            || tree::upsert_node(win, &editor(&buffer)).is_err()
             || tree::upsert_node(win, &status("Cmd+S to save")).is_err()
         {
             let _ = window::close(win);
@@ -471,7 +995,7 @@ impl bindings::Guest for Component {
                         selected = index as u32;
                         load_note(index, &mut buffer);
                         let _ = tree::upsert_node(win, &sidebar(Some(selected)));
-                        let _ = tree::upsert_node(win, &editor(buffer.as_str()));
+                        let _ = tree::upsert_node(win, &editor(&buffer));
                         let _ = tree::upsert_node(win, &status("loaded"));
                         dirty = false;
                     }
@@ -492,7 +1016,7 @@ impl bindings::Guest for Component {
                         buffer.clear();
                         let _ = tree::upsert_node(win, &note_row(index));
                         let _ = tree::upsert_node(win, &sidebar(Some(selected)));
-                        let _ = tree::upsert_node(win, &editor(buffer.as_str()));
+                        let _ = tree::upsert_node(win, &editor(&buffer));
                         let _ = tree::upsert_node(win, &status("new note"));
                         dirty = false;
                     } else {
@@ -515,34 +1039,45 @@ impl bindings::Guest for Component {
                     }
                     dirty = true;
                 }
-                // A drawn host (Linux, Windows) sends the added characters and
-                // relies on the guest to render them, so this path appends and
-                // re-lowers.
+                // A drawn host (Linux, Windows) sends committed characters and
+                // relies on the guest to render them. Insert at the caret,
+                // replacing any selection, and re-lower. Control combinations
+                // (Ctrl+C and friends) arrive as Key events with no text, so
+                // this only ever carries real typed characters.
                 Some(types::Event::TextInput(text)) => {
-                    for byte in text.as_bytes() {
-                        let printable = byte.is_ascii_graphic() || *byte == b' ';
-                        if printable {
-                            buffer.push(*byte);
-                        }
+                    let only_printable = text
+                        .as_bytes()
+                        .iter()
+                        .all(|byte| byte.is_ascii_graphic() || *byte == b' ');
+                    if only_printable && !text.is_empty() {
+                        buffer.insert_str(&text);
+                        dirty = true;
+                        let _ = tree::upsert_node(win, &editor(&buffer));
+                        let _ = tree::upsert_node(win, &status("editing"));
                     }
-                    let _ = tree::upsert_node(win, &editor(buffer.as_str()));
-                    let _ = tree::upsert_node(win, &status("editing"));
                 }
-                Some(types::Event::Key(key)) => {
-                    if key.pressed && key.key.as_bytes() == b"Backspace" {
-                        buffer.pop();
-                        let _ = tree::upsert_node(win, &editor(buffer.as_str()));
-                    }
-                    // Ctrl or Cmd plus S saves, the shortcut every note app has.
-                    if key.pressed
-                        && key.key.as_bytes() == b"s"
-                        && (key.modifiers.control || key.modifiers.meta)
-                    {
-                        if save_note(selected as usize, &buffer) {
+                // The drawn path implements every editing behavior here, since
+                // it paints its own text and has no native control to defer to.
+                // Shortcuts fire on Control (Linux, Windows) or Meta/Command
+                // (macOS) so the same guest works on every host.
+                Some(types::Event::Key(key)) if key.pressed => {
+                    match apply_drawn_key(&mut buffer, &key, selected as usize) {
+                        DrawnKeyOutcome::Ignored => {}
+                        DrawnKeyOutcome::Edited => {
+                            dirty = true;
+                            let _ = tree::upsert_node(win, &editor(&buffer));
+                        }
+                        DrawnKeyOutcome::Moved => {
+                            // Caret and selection live in the guest; re-lower so
+                            // the painter can show the new selection highlight.
+                            let _ = tree::upsert_node(win, &editor(&buffer));
+                        }
+                        DrawnKeyOutcome::Saved => {
                             saved_any = true;
                             dirty = false;
                             let _ = tree::upsert_node(win, &status("saved"));
-                        } else {
+                        }
+                        DrawnKeyOutcome::SaveDenied => {
                             let _ = tree::upsert_node(win, &status("save denied"));
                         }
                     }
@@ -589,3 +1124,185 @@ impl bindings::Guest for Component {
 }
 
 bindings::export!(Component with_types_in bindings);
+
+#[cfg(test)]
+mod tests {
+    //! Editor-logic tests that run natively — no host, no wasm, no clipboard.
+    //! They cover the parts of the YC demo interaction the guest owns on the
+    //! drawn path: shortcut translation, selection, editing, and undo/redo.
+    //! Persistence (save/load across close/reopen) rides the real file host and
+    //! is proven by the cross-platform matrix run, not here.
+    use super::*;
+
+    fn typed(buffer: &mut NoteBuffer, text: &str) {
+        buffer.insert_str(text);
+    }
+
+    // ---- shortcut translation ----
+
+    #[test]
+    fn control_and_meta_both_trigger_editing_shortcuts() {
+        // Linux/Windows use Control, macOS uses Meta; the same guest must honor
+        // either, so a chord is control OR meta.
+        assert_eq!(classify_key("c", true, false, false), KeyAction::Copy);
+        assert_eq!(classify_key("c", false, true, false), KeyAction::Copy);
+        assert_eq!(classify_key("a", true, false, false), KeyAction::SelectAll);
+        assert_eq!(classify_key("v", false, true, false), KeyAction::Paste);
+        assert_eq!(classify_key("x", true, false, false), KeyAction::Cut);
+        assert_eq!(classify_key("s", true, false, false), KeyAction::Save);
+    }
+
+    #[test]
+    fn undo_redo_shortcuts_distinguish_shift_and_y() {
+        assert_eq!(classify_key("z", true, false, false), KeyAction::Undo);
+        assert_eq!(classify_key("z", true, false, true), KeyAction::Redo);
+        assert_eq!(classify_key("Z", true, false, true), KeyAction::Redo);
+        // Ctrl+Y is the Windows redo habit.
+        assert_eq!(classify_key("y", true, false, false), KeyAction::Redo);
+    }
+
+    #[test]
+    fn navigation_keys_need_no_modifier_and_shift_extends() {
+        assert_eq!(classify_key("Backspace", false, false, false), KeyAction::Backspace);
+        assert_eq!(classify_key("Delete", false, false, false), KeyAction::DeleteForward);
+        assert_eq!(
+            classify_key("ArrowLeft", false, false, false),
+            KeyAction::MoveLeft { extend: false }
+        );
+        assert_eq!(
+            classify_key("ArrowRight", false, false, true),
+            KeyAction::MoveRight { extend: true }
+        );
+        assert_eq!(
+            classify_key("Home", false, false, true),
+            KeyAction::MoveHome { extend: true }
+        );
+        assert_eq!(classify_key("End", false, false, false), KeyAction::MoveEnd { extend: false });
+    }
+
+    #[test]
+    fn a_plain_letter_is_not_a_shortcut() {
+        // Without a chord, a letter is text, handled by the TextInput path, so
+        // the key handler must not claim it.
+        assert_eq!(classify_key("a", false, false, false), KeyAction::None);
+        assert_eq!(classify_key("z", false, false, false), KeyAction::None);
+    }
+
+    // ---- editing ----
+
+    #[test]
+    fn typing_inserts_at_the_caret_not_only_the_end() {
+        let mut b = NoteBuffer::new();
+        typed(&mut b, "helo");
+        b.move_left(false); // caret between "hel" and "o"
+        typed(&mut b, "l"); // "hello"
+        assert_eq!(b.as_str(), "hello");
+        assert_eq!(b.cursor, 4);
+    }
+
+    #[test]
+    fn backspace_and_delete_remove_around_the_caret() {
+        let mut b = NoteBuffer::new();
+        typed(&mut b, "abcd");
+        b.backspace(); // "abc"
+        assert_eq!(b.as_str(), "abc");
+        b.move_home(false);
+        b.delete_forward(); // "bc"
+        assert_eq!(b.as_str(), "bc");
+        assert_eq!(b.cursor, 0);
+    }
+
+    #[test]
+    fn insert_at_capacity_never_grows_or_panics() {
+        let mut b = NoteBuffer::new();
+        // Fill past capacity; the editor must clamp, not panic.
+        for _ in 0..(NOTE_CAPACITY + 50) {
+            typed(&mut b, "x");
+        }
+        assert_eq!(b.len, NOTE_CAPACITY);
+        assert_eq!(b.as_str().len(), NOTE_CAPACITY);
+    }
+
+    // ---- selection ----
+
+    #[test]
+    fn shift_arrows_build_a_selection_and_typing_replaces_it() {
+        let mut b = NoteBuffer::new();
+        typed(&mut b, "hello");
+        b.move_home(false);
+        b.move_right(true); // select "h"
+        b.move_right(true); // select "he"
+        assert!(b.has_selection());
+        assert_eq!(b.selected_text(), "he");
+        typed(&mut b, "HE"); // replaces selection
+        assert_eq!(b.as_str(), "HEllo");
+        assert!(!b.has_selection());
+    }
+
+    #[test]
+    fn select_all_spans_the_whole_buffer() {
+        let mut b = NoteBuffer::new();
+        typed(&mut b, "note body");
+        b.select_all();
+        assert_eq!(b.selected_text(), "note body");
+        b.delete_selection();
+        assert_eq!(b.as_str(), "");
+    }
+
+    #[test]
+    fn moving_without_shift_collapses_the_selection() {
+        let mut b = NoteBuffer::new();
+        typed(&mut b, "abcde");
+        b.select_all();
+        b.move_left(false); // collapse to left edge
+        assert!(!b.has_selection());
+        assert_eq!(b.cursor, 0);
+    }
+
+    // ---- undo / redo ----
+
+    #[test]
+    fn undo_then_redo_walks_edit_history() {
+        let mut b = NoteBuffer::new();
+        typed(&mut b, "one");
+        typed(&mut b, " two");
+        assert_eq!(b.as_str(), "one two");
+        assert!(b.undo());
+        assert_eq!(b.as_str(), "one");
+        assert!(b.redo());
+        assert_eq!(b.as_str(), "one two");
+    }
+
+    #[test]
+    fn undo_restores_caret_and_selection_position() {
+        let mut b = NoteBuffer::new();
+        typed(&mut b, "abc");
+        let before = (b.cursor, b.anchor);
+        typed(&mut b, "d");
+        assert!(b.undo());
+        assert_eq!((b.cursor, b.anchor), before);
+    }
+
+    #[test]
+    fn editing_after_undo_drops_the_redo_future() {
+        let mut b = NoteBuffer::new();
+        typed(&mut b, "a");
+        typed(&mut b, "b");
+        assert!(b.undo()); // back to "a"
+        typed(&mut b, "c"); // forks history
+        assert_eq!(b.as_str(), "ac");
+        // The old "ab" future is gone.
+        assert!(!b.redo());
+        assert_eq!(b.as_str(), "ac");
+    }
+
+    #[test]
+    fn a_noop_backspace_does_not_consume_an_undo_step() {
+        let mut b = NoteBuffer::new();
+        typed(&mut b, "x");
+        b.move_home(false);
+        b.backspace(); // caret at 0, nothing to delete
+        assert!(b.undo()); // undoes the typing, not a phantom step
+        assert_eq!(b.as_str(), "");
+    }
+}

--- a/crates/adapter-common/src/painter.rs
+++ b/crates/adapter-common/src/painter.rs
@@ -248,7 +248,46 @@ pub fn paint_placements_bitmap(
                 let cell = drawtext::text_width("x", text_scale).max(1) as f32;
                 let per_line = (((pw - inset * 2.0) / cell).floor() as usize).max(1);
                 let line_h = th + 2.0 * scale;
-                let mut line_y = py + inset;
+                let origin_x = px + inset;
+                let origin_y = py + inset;
+
+                // Selection and caret ride on the same fixed-cell grid the text
+                // wraps on, so an offset in characters maps straight to a cell.
+                // The app reports byte offsets, which equal character offsets
+                // for the ASCII the drawn path accepts. Paint the selection wash
+                // first so the glyphs land on top of it.
+                if let Some((cursor, anchor)) = placement.text_cursor {
+                    let glyphs = label.chars().count();
+                    let cursor = (cursor as usize).min(glyphs);
+                    let anchor = (anchor as usize).min(glyphs);
+                    let (sel_start, sel_end) = (cursor.min(anchor), cursor.max(anchor));
+
+                    let cell_rect = |offset: usize| -> (f32, f32) {
+                        let row = offset / per_line;
+                        let col = offset - row * per_line;
+                        (origin_x + col as f32 * cell, origin_y + row as f32 * line_h)
+                    };
+
+                    // A wash cell per selected character keeps wrapping exact
+                    // without a per-row span calculation.
+                    let mut offset = sel_start;
+                    while offset < sel_end {
+                        let (cx, cy) = cell_rect(offset);
+                        if let Some(clipped) = clip_fill((cx, cy, cell, th)) {
+                            fill_rect(buffer, width, height, clipped, COLOR_SELECTION)
+                        };
+                        offset += 1;
+                    }
+
+                    // The caret is a thin bar at the cursor cell's left edge.
+                    let (caret_x, caret_y) = cell_rect(cursor);
+                    let caret_w = (scale).max(1.0);
+                    if let Some(clipped) = clip_fill((caret_x, caret_y, caret_w, th)) {
+                        fill_rect(buffer, width, height, clipped, COLOR_FIELD_TEXT)
+                    };
+                }
+
+                let mut line_y = origin_y;
                 let mut rest = label;
                 while !rest.is_empty() && line_y + th <= py + ph - inset {
                     let take = rest.chars().count().min(per_line);
@@ -262,7 +301,7 @@ pub fn paint_placements_bitmap(
                         buffer,
                         width,
                         height,
-                        ((px + inset) as i32, line_y as i32),
+                        ((origin_x) as i32, line_y as i32),
                         text_scale,
                         COLOR_FIELD_TEXT,
                         line,
@@ -399,6 +438,7 @@ mod tests {
             checked: None,
             value: None,
             selection: None,
+            text_cursor: None,
             clip: None,
             x,
             y,
@@ -446,6 +486,47 @@ mod tests {
         assert!((84..100u32)
             .flat_map(|y| (10..110u32).map(move |x| (x, y)))
             .any(|(x, y)| at(x, y) == COLOR_TEXT));
+    }
+
+    #[test]
+    fn text_area_paints_caret_and_selection_when_a_cursor_is_set() {
+        let (w, h) = (200u32, 80u32);
+        let mut buffer = vec![0u32; (w * h) as usize];
+        // A text area whose app selected "he" of "hello" with the caret at 2.
+        let mut area = placement(WidgetKind::TextArea, "hello", 10.0, 10.0, 180.0, 60.0);
+        area.text_cursor = Some((2, 0));
+        paint_placements_bitmap(&mut buffer, w, h, 1.0, &[area], PaintInteraction::default());
+        let at = |x: u32, y: u32| buffer[(y * w + x) as usize];
+        // The selection wash tints the first cells of the first text row.
+        let inset = 4u32;
+        let row = 14u32 + 2; // origin_y + a couple pixels into the glyph band
+        assert!(
+            (10 + inset..10 + inset + 6).any(|x| at(x, row) == COLOR_SELECTION),
+            "the selected characters must be washed with the selection color"
+        );
+        // Somewhere along the row a caret bar (field-text color) appears.
+        assert!(
+            (10 + inset..10 + inset + 40)
+                .flat_map(|x| (14..30u32).map(move |y| (x, y)))
+                .any(|(x, y)| at(x, y) == COLOR_FIELD_TEXT),
+            "a caret bar must be painted at the cursor"
+        );
+    }
+
+    #[test]
+    fn text_area_without_a_cursor_paints_no_selection_wash() {
+        let (w, h) = (200u32, 80u32);
+        let mut buffer = vec![0u32; (w * h) as usize];
+        let area = placement(WidgetKind::TextArea, "hello", 10.0, 10.0, 180.0, 60.0);
+        paint_placements_bitmap(&mut buffer, w, h, 1.0, &[area], PaintInteraction::default());
+        let at = |x: u32, y: u32| buffer[(y * w + x) as usize];
+        // A passive text area (no caret reported) must not tint any cell.
+        assert!(
+            !(10..190u32)
+                .flat_map(|x| (10..70u32).map(move |y| (x, y)))
+                .any(|(x, y)| at(x, y) == COLOR_SELECTION),
+            "no selection wash without a reported cursor"
+        );
     }
 
     #[test]

--- a/crates/adapter-common/src/ui.rs
+++ b/crates/adapter-common/src/ui.rs
@@ -349,6 +349,10 @@ pub struct WidgetNode {
     /// Zero-based index of the selected child, for selectable container
     /// kinds (list view, tree view).
     pub selected: Option<u32>,
+    /// Caret and selection (byte offsets into `label`) for a text widget the
+    /// app edits itself. Painting hosts draw the caret and selection wash;
+    /// native-control hosts ignore it. `None` leaves the text a passive label.
+    pub text_cursor: Option<(u32, u32)>,
 }
 
 impl WidgetNode {
@@ -364,7 +368,21 @@ impl WidgetNode {
             checked: None,
             value: None,
             selected: None,
+            text_cursor: None,
         }
+    }
+
+    /// Attach a text caret and selection (cursor, anchor) for a text widget
+    /// the app edits itself. Only text kinds may carry one.
+    pub fn with_text_cursor(mut self, cursor: u32, anchor: u32) -> Result<Self, UiAdapterError> {
+        if !matches!(self.kind, WidgetKind::TextArea | WidgetKind::TextField) {
+            return Err(UiAdapterError::Unsupported(format!(
+                "widget kind {:?} cannot carry a text caret",
+                self.kind
+            )));
+        }
+        self.text_cursor = Some((cursor, anchor));
+        Ok(self)
     }
 
     /// Attach on/off state (checkbox, radio, switch).
@@ -1031,6 +1049,10 @@ pub struct WidgetPlacement {
     /// lowering time for selectable containers. Painters draw the
     /// selection highlight here; `None` means nothing is selected.
     pub selection: Option<(f32, f32, f32, f32)>,
+    /// Caret and selection (cursor, anchor) as byte offsets into `label`, for
+    /// a text widget the app edits itself. Painting hosts draw a caret bar at
+    /// `cursor` and a wash over `[min, max)`; `None` paints a passive label.
+    pub text_cursor: Option<(u32, u32)>,
     /// Clip rectangle (x, y, w, h) in logical pixels, set for widgets
     /// inside Scroll containers; painters must not draw outside it.
     pub clip: Option<(f32, f32, f32, f32)>,

--- a/crates/adapter-common/src/vector_text.rs
+++ b/crates/adapter-common/src/vector_text.rs
@@ -65,6 +65,37 @@ impl TextEngine {
         layout.align(Alignment::Start, AlignmentOptions::default());
         layout
     }
+
+    /// Width of the first `chars` characters of `text`, laid out unwrapped.
+    /// Used to place the caret and selection edges: the note is short and
+    /// single line in practice, so an unwrapped prefix measures the exact x.
+    fn prefix_width(&mut self, text: &str, chars: usize, scale: f32) -> f32 {
+        if chars == 0 {
+            return 0.0;
+        }
+        let end = text
+            .char_indices()
+            .nth(chars)
+            .map(|(index, _)| index)
+            .unwrap_or(text.len());
+        let prefix = text.get(..end).unwrap_or(text);
+        if prefix.is_empty() {
+            return 0.0;
+        }
+        self.layout_text(prefix, scale, None).width()
+    }
+
+    /// Height of one text line at this scale, for sizing the caret and wash.
+    fn line_height(&mut self, scale: f32) -> f32 {
+        // "Xg" spans an ascender and descender, a stable line-box proxy.
+        self.layout_text("Xg", scale, None).height()
+    }
+}
+
+/// Clamp a character offset to a string's character count, so a caret past the
+/// end of the text lands at the end rather than out of range.
+fn clamp_char_offset(text: &str, offset: usize) -> usize {
+    offset.min(text.chars().count())
 }
 
 fn argb(color: u32) -> AlphaColor<vello_cpu::color::Srgb> {
@@ -266,9 +297,48 @@ pub fn try_paint_placements(
                         (ph - 2.0 * scale).max(0.0),
                         3.0 * scale,
                     );
+                    let inset = 4.0 * scale;
+                    let inner_width = (pw - inset * 2.0).max(1.0);
+
+                    // Selection wash and caret sit under the glyphs. Parley is
+                    // proportional, so positions come from measuring prefixes
+                    // rather than a fixed cell. The note is short and single
+                    // line in practice; measuring the prefix width places the
+                    // caret exactly there, and the selection spans between two
+                    // such measurements.
+                    if let Some((cursor, anchor)) = placement.text_cursor {
+                        let cursor = clamp_char_offset(label, cursor as usize);
+                        let anchor = clamp_char_offset(label, anchor as usize);
+                        let sel_start = cursor.min(anchor);
+                        let sel_end = cursor.max(anchor);
+                        let line_top = py + inset;
+                        let line_h = engine.line_height(scale);
+
+                        if sel_start != sel_end {
+                            let x0 = px + inset + engine.prefix_width(label, sel_start, scale);
+                            let x1 = px + inset + engine.prefix_width(label, sel_end, scale);
+                            fill(
+                                &mut ctx,
+                                COLOR_SELECTION,
+                                x0,
+                                line_top,
+                                (x1 - x0).max(1.0),
+                                line_h,
+                            );
+                        }
+
+                        let caret_x = px + inset + engine.prefix_width(label, cursor, scale);
+                        fill(
+                            &mut ctx,
+                            COLOR_FIELD_TEXT,
+                            caret_x,
+                            line_top,
+                            scale.max(1.0),
+                            line_h,
+                        );
+                    }
+
                     if !label.is_empty() {
-                        let inset = 4.0 * scale;
-                        let inner_width = (pw - inset * 2.0).max(1.0);
                         let layout = engine.layout_text(label, scale, Some(inner_width));
                         let _ = draw_layout(
                             &mut ctx,
@@ -470,6 +540,7 @@ mod tests {
             checked: None,
             value: None,
             selection: None,
+            text_cursor: None,
             clip: None,
             x: 10.0,
             y: 10.0,
@@ -529,6 +600,7 @@ mod tests {
             checked: None,
             value: None,
             selection: None,
+            text_cursor: None,
             clip: None,
             x: 10.0,
             y: 10.0,
@@ -590,6 +662,7 @@ mod text_area_tests {
             checked: None,
             value: None,
             selection: None,
+            text_cursor: None,
             clip: None,
             x: 0.0,
             y: 0.0,

--- a/crates/adapter-linux/Cargo.toml
+++ b/crates/adapter-linux/Cargo.toml
@@ -24,3 +24,6 @@ winit = { version = "0.30", default-features = false, features = ["x11", "rwh_06
 # renderer behind the draw pass moves to vello/wgpu later (plan section 7.5);
 # softbuffer keeps the pipeline proof dependency-light.
 softbuffer = { version = "0.4", default-features = false, features = ["x11", "x11-dlopen"] }
+# OS clipboard for the drawn path's Cut/Copy/Paste. Text-only (no image-data),
+# so the X11 backend stays dependency-light and matches the Xvfb CI proof.
+arboard.workspace = true

--- a/crates/adapter-linux/src/clipboard.rs
+++ b/crates/adapter-linux/src/clipboard.rs
@@ -1,0 +1,51 @@
+//! OS clipboard access for the drawn path's Cut/Copy/Paste.
+//!
+//! The drawn host paints its own text, so the guest can only reach the system
+//! clipboard through the host. arboard is opened per call rather than cached: a
+//! long-lived handle would hold the X11 selection owner across the whole
+//! session, and opening on demand keeps the surface a plain read/write with no
+//! background state to reason about. macOS is not built here — its native text
+//! control owns Cut/Copy/Paste directly.
+//!
+//! Off Linux this crate has no native window backend, so these mirror
+//! `winit_native`'s stubs and report the feature as unsupported.
+
+use krate_adapter_common::ui::UiAdapterError;
+
+/// Read UTF-8 text from the system clipboard.
+#[cfg(target_os = "linux")]
+pub(crate) fn read_text() -> Result<String, UiAdapterError> {
+    let mut clipboard =
+        arboard::Clipboard::new().map_err(|err| UiAdapterError::Internal(err.to_string()))?;
+    match clipboard.get_text() {
+        Ok(text) => Ok(text),
+        // An empty or non-text clipboard is not an error: pasting nothing
+        // should leave the note untouched, not fail the whole edit.
+        Err(arboard::Error::ContentNotAvailable) => Ok(String::new()),
+        Err(err) => Err(UiAdapterError::Internal(err.to_string())),
+    }
+}
+
+/// Write UTF-8 text to the system clipboard.
+#[cfg(target_os = "linux")]
+pub(crate) fn write_text(text: &str) -> Result<(), UiAdapterError> {
+    let mut clipboard =
+        arboard::Clipboard::new().map_err(|err| UiAdapterError::Internal(err.to_string()))?;
+    clipboard
+        .set_text(text.to_string())
+        .map_err(|err| UiAdapterError::Internal(err.to_string()))
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn read_text() -> Result<String, UiAdapterError> {
+    Err(UiAdapterError::Unsupported(
+        "clipboard is only wired on the native Linux backend".to_string(),
+    ))
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn write_text(_text: &str) -> Result<(), UiAdapterError> {
+    Err(UiAdapterError::Unsupported(
+        "clipboard is only wired on the native Linux backend".to_string(),
+    ))
+}

--- a/crates/adapter-linux/src/lib.rs
+++ b/crates/adapter-linux/src/lib.rs
@@ -32,6 +32,8 @@ pub const HOST_FAMILY: &str = "linux";
 /// the same UI contract as macOS and Windows before the winit bridge lands.
 pub mod winit_native;
 
+mod clipboard;
+
 #[derive(Debug, Default)]
 pub struct LinuxUiAdapter {
     draft: DraftUiAdapter,
@@ -511,6 +513,19 @@ impl UiAdapter for LinuxWinitPrototypeUiAdapter {
 
     fn queue_text_changed(&self, event: TextChangedEvent) -> Result<(), UiAdapterError> {
         self.headless.queue_text_changed(event)
+    }
+
+    // The drawn path paints its own text, so Cut/Copy/Paste can only work if
+    // the guest reaches the real OS clipboard. macOS never gets here — its
+    // NSTextField owns Cut/Copy/Paste natively — so this lives on the drawn
+    // adapters alone. Capability gating (`ui.clipboard:read`/`write`) happens
+    // in the runtime before either call is dispatched.
+    fn read_clipboard_text(&self) -> Result<String, UiAdapterError> {
+        clipboard::read_text()
+    }
+
+    fn write_clipboard_text(&self, text: &str) -> Result<(), UiAdapterError> {
+        clipboard::write_text(text)
     }
 
     fn pump_event_loop_once(

--- a/crates/adapter-macos/Cargo.toml
+++ b/crates/adapter-macos/Cargo.toml
@@ -13,5 +13,5 @@ libc.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.4"
-objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSApplication", "NSButton", "NSCell", "NSColor", "NSControl", "NSEvent", "NSFont", "NSGraphics", "NSMenu", "NSMenuItem", "NSOpenPanel", "NSPanel", "NSSavePanel", "NSText", "NSResponder", "NSRunningApplication", "NSTextField", "NSView", "NSWindow", "objc2-core-foundation"] }
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSAlert", "NSApplication", "NSButton", "NSCell", "NSColor", "NSControl", "NSEvent", "NSFont", "NSGraphics", "NSMenu", "NSMenuItem", "NSOpenPanel", "NSPanel", "NSSavePanel", "NSText", "NSResponder", "NSRunningApplication", "NSTextField", "NSView", "NSWindow", "objc2-core-foundation"] }
 objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSArray", "NSGeometry", "NSURL", "NSNotification", "NSObject", "NSRunLoop", "NSString", "objc2-core-foundation"] }

--- a/crates/adapter-macos/src/appkit.rs
+++ b/crates/adapter-macos/src/appkit.rs
@@ -1079,8 +1079,8 @@ mod platform {
     use objc2::{define_class, msg_send, sel, DefinedClass, MainThreadMarker, MainThreadOnly};
     use objc2_app_kit::{
         NSApplication, NSApplicationActivationPolicy, NSBackingStoreType, NSButton, NSColor,
-        NSControl, NSEventMask, NSFont, NSMenu, NSMenuItem, NSTextField, NSView, NSWindow,
-        NSWindowDelegate, NSWindowStyleMask,
+        NSControl, NSEventMask, NSEventModifierFlags, NSFont, NSMenu, NSMenuItem, NSTextField,
+        NSView, NSWindow, NSWindowDelegate, NSWindowStyleMask,
     };
     use objc2_foundation::{
         NSDefaultRunLoopMode, NSNotification, NSObject, NSObjectProtocol, NSPoint, NSRect, NSSize,
@@ -1766,8 +1766,18 @@ mod platform {
                     &NSString::from_str(title),
                     Some(selector),
                     &NSString::from_str(key),
-                );
+                )
             };
+            // Undo/Redo route through the responder chain to the focused text
+            // field's field editor, which keeps its own undo stack. Without
+            // these menu items the Cmd+Z / Cmd+Shift+Z keystrokes reach nothing.
+            add("Undo", sel!(undo:), "z");
+            // Redo is Cmd+Shift+Z: same key equivalent, plus the Shift mask.
+            let redo_item = add("Redo", sel!(redo:), "z");
+            redo_item.setKeyEquivalentModifierMask(
+                NSEventModifierFlags::Command | NSEventModifierFlags::Shift,
+            );
+            edit_menu.addItem(&NSMenuItem::separatorItem(mtm));
             add("Cut", sel!(cut:), "x");
             add("Copy", sel!(copy:), "c");
             add("Paste", sel!(paste:), "v");
@@ -2265,6 +2275,7 @@ mod tests {
                 checked: None,
                 value: None,
                 selected: None,
+                text_cursor: None,
             },
         )
         .expect("set root widget");

--- a/crates/adapter-macos/src/consent.rs
+++ b/crates/adapter-macos/src/consent.rs
@@ -61,6 +61,17 @@ pub fn present_consent_window(
     ))
 }
 
+/// Show a native alert explaining the app was refused because a required
+/// permission was not granted. Used on the double-click path so the app does
+/// not just fail silently. `denied` lists the capability strings still missing.
+#[cfg(target_os = "macos")]
+pub fn present_denied_alert(app_name: &str, denied: &[String]) {
+    platform::denied_alert(app_name, denied);
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn present_denied_alert(_app_name: &str, _denied: &[String]) {}
+
 #[cfg(target_os = "macos")]
 mod platform {
     use super::{ConsentChoice, ConsentItem};
@@ -69,12 +80,42 @@ mod platform {
     use objc2::runtime::AnyObject;
     use objc2::{define_class, msg_send, sel, DefinedClass, MainThreadMarker, MainThreadOnly};
     use objc2_app_kit::{
-        NSApplication, NSBackingStoreType, NSButton, NSColor, NSControlStateValueOff,
-        NSControlStateValueOn, NSFont, NSTextField, NSView, NSWindow, NSWindowStyleMask,
+        NSAlert, NSAlertStyle, NSApplication, NSBackingStoreType, NSButton, NSColor,
+        NSControlStateValueOff, NSControlStateValueOn, NSFont, NSTextField, NSView, NSWindow,
+        NSWindowStyleMask,
     };
     use objc2_foundation::{NSPoint, NSRect, NSSize, NSString};
     use std::cell::Cell;
     use std::rc::Rc;
+
+    /// A native alert shown when the app is refused for missing permissions.
+    pub(super) fn denied_alert(app_name: &str, denied: &[String]) {
+        let Some(mtm) = MainThreadMarker::new() else {
+            return;
+        };
+        let list = denied
+            .iter()
+            .map(|cap| format!("• {cap}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let body = if list.is_empty() {
+            format!("{app_name} needs a permission you did not grant, so it will not run.")
+        } else {
+            format!(
+                "{app_name} will not run because it was not allowed to:\n\n{list}\n\n\
+                 Open it again and allow it to continue."
+            )
+        };
+        let alert = NSAlert::new(mtm);
+        alert.setAlertStyle(NSAlertStyle::Warning);
+        alert.setMessageText(&NSString::from_str("Permission needed"));
+        alert.setInformativeText(&NSString::from_str(&body));
+        alert.addButtonWithTitle(&NSString::from_str("OK"));
+        let app = NSApplication::sharedApplication(mtm);
+        #[allow(deprecated)]
+        app.activateIgnoringOtherApps(true);
+        alert.runModal();
+    }
 
     /// Modal return codes. Distinct so the caller can tell Open from Cancel;
     /// AppKit reserves nothing in this range for its own responses here.

--- a/crates/adapter-macos/src/lib.rs
+++ b/crates/adapter-macos/src/lib.rs
@@ -805,6 +805,7 @@ mod tests {
             checked: Some(false),
             value: None,
             selection: None,
+            text_cursor: None,
             clip: None,
             clickable: false,
             role: None,

--- a/crates/adapter-macos/src/lib.rs
+++ b/crates/adapter-macos/src/lib.rs
@@ -25,7 +25,7 @@ use std::net::{SocketAddr, TcpStream};
 use std::path::Path;
 use std::time::Duration;
 
-pub use consent::{present_consent_window, ConsentChoice, ConsentItem};
+pub use consent::{present_consent_window, present_denied_alert, ConsentChoice, ConsentItem};
 pub use open_document::{choose_document, wait_for_opened_documents};
 
 pub use appkit::{

--- a/crates/adapter-windows/Cargo.toml
+++ b/crates/adapter-windows/Cargo.toml
@@ -17,3 +17,6 @@ winit = { version = "0.30", default-features = false, features = ["rwh_06"] }
 # CPU framebuffer for the first drawn-widget pass; the Windows backend needs
 # no feature flags. Vello/wgpu replaces the presenter later (plan 7.5).
 softbuffer = { version = "0.4", default-features = false }
+# OS clipboard for the drawn path's Cut/Copy/Paste. Text-only (no image-data),
+# so it pulls only the Win32 clipboard backend.
+arboard.workspace = true

--- a/crates/adapter-windows/src/clipboard.rs
+++ b/crates/adapter-windows/src/clipboard.rs
@@ -1,0 +1,47 @@
+//! OS clipboard access for the drawn path's Cut/Copy/Paste.
+//!
+//! The drawn host paints its own text, so the guest can only reach the system
+//! clipboard through the host. arboard is opened per call rather than cached,
+//! keeping the surface a plain read/write with no background state. Off Windows
+//! this crate has no native window backend, so these mirror `winit_native`'s
+//! stubs and report the feature as unsupported.
+
+use krate_adapter_common::ui::UiAdapterError;
+
+/// Read UTF-8 text from the system clipboard.
+#[cfg(target_os = "windows")]
+pub(crate) fn read_text() -> Result<String, UiAdapterError> {
+    let mut clipboard =
+        arboard::Clipboard::new().map_err(|err| UiAdapterError::Internal(err.to_string()))?;
+    match clipboard.get_text() {
+        Ok(text) => Ok(text),
+        // An empty or non-text clipboard is not an error: pasting nothing
+        // should leave the note untouched, not fail the whole edit.
+        Err(arboard::Error::ContentNotAvailable) => Ok(String::new()),
+        Err(err) => Err(UiAdapterError::Internal(err.to_string())),
+    }
+}
+
+/// Write UTF-8 text to the system clipboard.
+#[cfg(target_os = "windows")]
+pub(crate) fn write_text(text: &str) -> Result<(), UiAdapterError> {
+    let mut clipboard =
+        arboard::Clipboard::new().map_err(|err| UiAdapterError::Internal(err.to_string()))?;
+    clipboard
+        .set_text(text.to_string())
+        .map_err(|err| UiAdapterError::Internal(err.to_string()))
+}
+
+#[cfg(not(target_os = "windows"))]
+pub(crate) fn read_text() -> Result<String, UiAdapterError> {
+    Err(UiAdapterError::Unsupported(
+        "clipboard is only wired on the native Windows backend".to_string(),
+    ))
+}
+
+#[cfg(not(target_os = "windows"))]
+pub(crate) fn write_text(_text: &str) -> Result<(), UiAdapterError> {
+    Err(UiAdapterError::Unsupported(
+        "clipboard is only wired on the native Windows backend".to_string(),
+    ))
+}

--- a/crates/adapter-windows/src/lib.rs
+++ b/crates/adapter-windows/src/lib.rs
@@ -33,6 +33,8 @@ pub const HOST_FAMILY: &str = "windows";
 /// the same UI contract as macOS and Linux before the winit or Win32 bridge lands.
 pub mod winit_native;
 
+mod clipboard;
+
 #[derive(Debug, Default)]
 pub struct WindowsUiAdapter {
     draft: DraftUiAdapter,
@@ -510,6 +512,17 @@ impl UiAdapter for WindowsWinitPrototypeUiAdapter {
 
     fn queue_text_changed(&self, event: TextChangedEvent) -> Result<(), UiAdapterError> {
         self.headless.queue_text_changed(event)
+    }
+
+    // The drawn path paints its own text, so Cut/Copy/Paste can only work if
+    // the guest reaches the real OS clipboard. Capability gating
+    // (`ui.clipboard:read`/`write`) happens in the runtime before dispatch.
+    fn read_clipboard_text(&self) -> Result<String, UiAdapterError> {
+        clipboard::read_text()
+    }
+
+    fn write_clipboard_text(&self, text: &str) -> Result<(), UiAdapterError> {
+        clipboard::write_text(text)
     }
 
     fn pump_event_loop_once(

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -502,7 +502,10 @@ fn run_component(request: RunRequest) -> Result<u8> {
                 // vanishing. Terminal runs keep the text guidance below.
                 #[cfg(target_os = "macos")]
                 if request.consent {
-                    let denied = missing.iter().map(|cap| cap.to_string()).collect::<Vec<_>>();
+                    let denied = missing
+                        .iter()
+                        .map(|cap| cap.to_string())
+                        .collect::<Vec<_>>();
                     let app_name = manifest.app.name.as_str();
                     krate_adapter_macos::present_denied_alert(app_name, &denied);
                 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -497,6 +497,15 @@ fn run_component(request: RunRequest) -> Result<u8> {
                 for cap in &missing {
                     eprintln!("  - {cap}");
                 }
+                // On the double-click path there is no terminal to read, so a
+                // native alert explains the refusal instead of the app just
+                // vanishing. Terminal runs keep the text guidance below.
+                #[cfg(target_os = "macos")]
+                if request.consent {
+                    let denied = missing.iter().map(|cap| cap.to_string()).collect::<Vec<_>>();
+                    let app_name = manifest.app.name.as_str();
+                    krate_adapter_macos::present_denied_alert(app_name, &denied);
+                }
                 // Someone running a shared app for the first time hits this
                 // without knowing the vocabulary yet. Saying what is missing
                 // and stopping leaves them stuck, so name the two ways out and

--- a/crates/runtime/examples/phase3_appkit_runtime_smoke.rs
+++ b/crates/runtime/examples/phase3_appkit_runtime_smoke.rs
@@ -61,6 +61,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             checked: None,
             value: None,
             selected: None,
+            text_cursor: None,
         },
     )?;
     dispatcher.upsert_node(
@@ -79,6 +80,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             checked: None,
             value: None,
             selected: None,
+            text_cursor: None,
         },
     )?;
     dispatcher.upsert_node(
@@ -97,6 +99,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             checked: None,
             value: None,
             selected: None,
+            text_cursor: None,
         },
     )?;
 

--- a/crates/runtime/src/phase3_gui_host.rs
+++ b/crates/runtime/src/phase3_gui_host.rs
@@ -137,6 +137,7 @@ impl Phase3GuiHost {
                 checked: row_selected.or(node.checked),
                 value: node.value,
                 selection,
+                text_cursor: node.text_cursor,
                 clip,
                 x: rect.x,
                 y,
@@ -434,6 +435,13 @@ fn widget_node_from_wit(node: ui::types::WidgetNode) -> Result<WidgetNode, ui::t
             "widget kind {kind:?} cannot carry a selected index"
         )));
     }
+    // A caret only means something on an editable text widget. Rejecting it
+    // elsewhere keeps a stray value from silently riding on, say, a button.
+    if node.text_cursor.is_some() && !matches!(kind, WidgetKind::TextArea | WidgetKind::TextField) {
+        return Err(ui::types::UiError::Unsupported(format!(
+            "widget kind {kind:?} cannot carry a text caret"
+        )));
+    }
 
     Ok(WidgetNode {
         id,
@@ -445,6 +453,7 @@ fn widget_node_from_wit(node: ui::types::WidgetNode) -> Result<WidgetNode, ui::t
         checked: node.checked,
         value: node.value,
         selected: node.selected,
+        text_cursor: node.text_cursor.map(|tc| (tc.cursor, tc.anchor)),
     })
 }
 
@@ -922,5 +931,44 @@ mod tests {
         assert!(!press_focuses(WidgetKind::Button));
         assert!(!press_focuses(WidgetKind::Text));
         assert!(!press_focuses(WidgetKind::Stack));
+    }
+
+    fn wit_node(kind: ui::types::WidgetKind, cursor: Option<(u32, u32)>) -> ui::types::WidgetNode {
+        ui::types::WidgetNode {
+            id: 1,
+            parent: None,
+            kind,
+            label: Some("hello".to_string()),
+            role: None,
+            style: ui::types::Style {
+                width: Some(100.0),
+                height: Some(30.0),
+                grow: 0.0,
+                padding: 0.0,
+            },
+            checked: None,
+            value: None,
+            selected: None,
+            text_cursor: cursor.map(|(c, a)| ui::types::TextCursor {
+                cursor: c,
+                anchor: a,
+            }),
+        }
+    }
+
+    #[test]
+    fn a_text_caret_lowers_onto_a_text_widget() {
+        let node = widget_node_from_wit(wit_node(ui::types::WidgetKind::TextArea, Some((2, 0))))
+            .expect("a text area may carry a caret");
+        assert_eq!(node.text_cursor, Some((2, 0)));
+    }
+
+    #[test]
+    fn a_text_caret_on_a_non_text_widget_is_rejected() {
+        // A caret only means something on editable text; carrying one on, say,
+        // a button is a guest bug and must not silently pass through.
+        let err = widget_node_from_wit(wit_node(ui::types::WidgetKind::Button, Some((1, 1))))
+            .expect_err("a button cannot carry a text caret");
+        assert!(matches!(err, ui::types::UiError::Unsupported(_)));
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -24,6 +24,10 @@ allow = [
     # code, and it arrives with the TLS stack that lets `krate run <https url>`
     # verify who it is downloading a bundle from.
     "CDLA-Permissive-2.0",
+    # clipboard-win (arboard's Windows clipboard backend, pulled in to give the
+    # drawn path Cut/Copy/Paste) is published under the Boost Software License,
+    # a permissive OSI-approved license with no copyleft or attribution burden.
+    "BSL-1.0",
 ]
 # Confidence threshold for license expression detection.
 confidence-threshold = 0.8

--- a/wit/krate/phase3/deps/ui/ui.wit
+++ b/wit/krate/phase3/deps/ui/ui.wit
@@ -167,6 +167,21 @@ interface types {
     canvas,
   }
 
+  /// Caret and selection inside a text widget, as byte offsets into its label.
+  ///
+  /// Hosts that paint their own text (Linux, Windows) have no native control to
+  /// hold a caret, so an app that implements editing itself reports where the
+  /// caret and selection sit and the painter draws them. `cursor` is the caret;
+  /// `anchor` is the other end of the selection. Equal offsets mean no
+  /// selection, just a caret. Hosts that lower to a real OS control ignore this:
+  /// the control owns its own caret.
+  record text-cursor {
+    /// Caret position as a byte offset into the label, clamped to its length.
+    cursor: u32,
+    /// The other end of the selection. Equal to `cursor` means no selection.
+    anchor: u32,
+  }
+
   /// Minimal style block for the first widget protocol draft.
   record style {
     /// Optional width in logical pixels.
@@ -200,6 +215,9 @@ interface types {
     /// Zero-based index of the selected child, for selectable container
     /// kinds (list-view, tree-view). Out-of-range indices are rejected.
     selected: option<u32>,
+    /// Caret and selection for a text widget the app edits itself, drawn by
+    /// painting hosts. `none` leaves text caretless, as a passive label.
+    text-cursor: option<text-cursor>,
   }
 
   /// Top-level menu item.


### PR DESCRIPTION
The same `notes.krate` now supports the complete editing interaction on
macOS, Linux, and Windows — not just macOS.

## What changed
- **macOS**: already had Cut/Copy/Paste/Select All via the native NSTextField; added the missing **Undo/Redo** menu items (Cmd+Z / Cmd+Shift+Z through the field editor).
- **Drawn path (Linux/Windows)**: built the whole editor in the guest — `NoteBuffer` gains a cursor, a selection anchor, and a 32-deep snapshot undo/redo stack, with insert-at-caret, backspace, forward-delete, arrow/Home/End movement (Shift extends), select-all, and delete-selection.
- **Shortcuts**: one pure `classify_key()` maps key+modifiers to an action; a chord is Control (Linux/Windows) OR Meta (macOS), so the byte-identical guest honors each platform's native modifier.
- **Clipboard**: `krate:ui/clipboard` already existed end-to-end; the drawn adapters now implement it via `arboard` (text-only). Optional capability — deny it and the app still opens, types, and saves.
- **Visible caret + selection**: one deliberate UAPI addition — a `text-cursor` record on the widget node — threaded through the placement and both painters (bitmap monospace grid; vello prefix-width measurement). A caret on a non-text widget is rejected at lowering.

## Requirements met
Open by double-click, permission window before run, allow/deny, type & edit, Select All/Copy/Cut/Paste/Undo/Redo, Cmd-on-macOS / Ctrl-on-Win-Linux, switch notes without losing edits, close/reopen intact, permission-denial preserved (exit 5), and byte-identical `code.wasm` run on all three lanes.

## Verification
- Full matrix run `30125544269` **green on all three OS lanes** plus clippy, rustfmt, cargo-deny, and every evidence compare.
- Byte-identical proof: `code.wasm` built once in the fixtures job, downloaded by all three full-test lanes (Linux logs sha256 `9cb8311a…`).
- Local macOS: `krate run notes.krate --auto-grant -- quick` saves; withheld `fs.write` → exit 5; clipboard denied → app still runs and saves.
- Tests: guest unit tests (shortcut translation, selection, editing, undo/redo), painter tests (caret + selection wash), runtime tests (caret-lowering contract).

## Known gap
The drawn caret/selection is logic- and pixel-tested but **not screenshot-verified in CI** on a real Linux/Windows screen — the one thing worth eyeballing in a follow-up.